### PR TITLE
Format LogStash::Event for our purposes

### DIFF
--- a/lib/logstash-logger/formatter.rb
+++ b/lib/logstash-logger/formatter.rb
@@ -2,6 +2,24 @@ require 'logger'
 require 'socket'
 require 'time'
 
+# Override the #to_s function to suit our needs
+class LogStash::Event
+  if RUBY_ENGINE == "jruby"
+    public
+    def to_s
+      # Like SimpleFormatter from rails, when printing Event#to_s to print on console, terminate with \n
+      return self.sprintf("%{+yyyy-MM-dd'T'HH:mm:ss.SSSZ} %{host} %{message}\n")
+    end # def to_s
+  else
+    public
+    def to_s
+      # Like SimpleFormatter from rails, when printing Event#to_s to print on console, terminate with \n
+      # Since we stringify @timestamp with LogStashLogger::Formatter#build_event, don't call Time.iso8601 again on what is now a string.
+      return self.sprintf("#{self["@timestamp"]} %{host} %{message}\n")
+    end # def to_s
+  end
+end
+
 class LogStashLogger < ::Logger
   HOST = ::Socket.gethostname
 
@@ -39,7 +57,7 @@ class LogStashLogger < ::Logger
         event.tag(tag)
       end
 
-      # In case Time#to_json has been overridden
+      # In case Time#to_json has been overridden - I can't find where this would be the case though....
       if event.timestamp.is_a?(Time)
         event.timestamp = event.timestamp.iso8601(3)
       end


### PR DESCRIPTION
I'm sure adding \n to the Event#to_s method is not the most universally friendly way to put newlines on rails console output, but it certainly does the trick.

Also since we are stringifying time in our gem, which I can't really find a solid case for on my side, we have to take the iso8601 call out of Event#to_s since it doesn't make sense to call 

```
"2014-05-29T10:21:38.086+00:00".iso8601
```
