### PR TITLE
Feature: Add SSL certificate to logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,33 @@ Should you write to a UDP or TCP listener? It depends on your specific needs, bu
 
 For a more detailed discussion of UDP vs TCP, I recommend reading this article: [UDP vs. TCP](http://gafferongames.com/networking-for-game-programmers/udp-vs-tcp/)
 
+## SSL
+
+If you are using TCP then there is the option of adding an SSL certificate to the options hash on initialize.
+
+```ruby
+LogStashLogger.new(:port => 5228, :type => :tcp, :ssl_certificate => "/path/to/certificate.crt")
+```
+
+The SSL certificate and key can be generated using
+
+    openssl req -x509 -batch -nodes -newkey rsa:2048 -keyout logstash.key -out logstash.crt
+
+The following Logstash configuration is required for SSL:
+
+```ruby
+input {
+  tcp {
+    host => "0.0.0.0"
+    port => 5228
+    codec => json_lines
+    ssl_enable => true
+    ssl_cert => "/path/to/certificate.crt"
+    ssl_key => "/path/to/key.key"
+  }
+}
+```
+
 ## Ruby compatibility
 
 Verified to work with:

--- a/lib/logstash/connection.rb
+++ b/lib/logstash/connection.rb
@@ -5,12 +5,13 @@ module LogStash
     DEFAULT_HOST = '0.0.0.0'
     DEFAULT_TYPE = :udp
 
-    attr_reader :host, :port, :type
+    attr_reader :host, :port, :type, :ssl_certificate
 
     def initialize(opts)
       @host = opts[:host] || DEFAULT_HOST
       @port = opts[:port] || fail(ArgumentError, "Port is required")
       @type = opts[:type] || DEFAULT_TYPE
+      @ssl_certificate = opts[:ssl_certificate]
       @socket = nil
     end
 
@@ -42,12 +43,25 @@ module LogStash
     protected
 
     def connect
+      return ssl_connect if using_ssl?
       @socket = \
         case @type
         when :udp then UDPSocket.new.tap {|socket| socket.connect(@host, @port)}
         when :tcp then TCPSocket.new(@host, @port)
         else fail ArgumentError, 'Invalid connection type'
         end
+    end
+
+    def ssl_connect
+      raise "Not available on UDP" if @type == :udp
+      tcp_socket = TCPSocket.new(@host, @port)
+      openssl_cert = OpenSSL::X509::Certificate.new(::File.read(@ssl_certificate))
+      @socket = OpenSSL::SSL::SSLSocket.new(tcp_socket)
+      @socket.connect
+    end
+
+    def using_ssl?
+      !@ssl_certificate.nil?
     end
 
     def with_connection(&block)


### PR DESCRIPTION
The tcp input for logstash allows the data to be transmitted securely
using an SSL certificate. This commit adds a fourth (optional) argument
to the logger to specify the path of an ssl certificate. If this is set
then it will use a secure socket.

Most of the code in this commit is heavily inspired by https://github.com/elasticsearch/logstash-forwarder/blob/master/lib/lumberjack/client.rb#L76
