### PR TITLE
Update Device.new to not mutate passed options

### DIFF
--- a/lib/logstash-logger/device.rb
+++ b/lib/logstash-logger/device.rb
@@ -15,6 +15,7 @@ module LogStashLogger
     autoload :Stdout, 'logstash-logger/device/stdout'
 
     def self.new(opts)
+      opts = opts.dup
       type = opts.delete(:type) || DEFAULT_TYPE
 
       device_klass_for(type).new(opts)


### PR DESCRIPTION
This fixes an issue I was having, where part of my configuration was being deleted once it got into this method.
