### PR TITLE
Flexible device type

### DIFF
--- a/lib/logstash-logger/device.rb
+++ b/lib/logstash-logger/device.rb
@@ -22,7 +22,7 @@ module LogStashLogger
     end
 
     def self.device_klass_for(type)
-      case type
+      case type.to_sym
         when :udp then UDP
         when :tcp then TCP
         when :unix then Unix

--- a/spec/device_spec.rb
+++ b/spec/device_spec.rb
@@ -20,4 +20,14 @@ describe LogStashLogger::Device do
     end
   end
 
+  context "when configuration type is a String" do
+    let(:configuration) { {type: "udp", port: port} }
+
+    subject(:new_device) { described_class.new(configuration) }
+
+    it "is flexible and can except a device type that is a string" do
+      expect(new_device).to be_a LogStashLogger::Device::UDP
+    end
+  end
+
 end


### PR DESCRIPTION
@dwbutler
- I added a spec for the previous PR https://github.com/dwbutler/logstash-logger/pull/18
- I updated `device_klass_for` to accept more flexible input.

I using environment variables to set the device type to be different in staging vs production.

```
ENV['LOGSTASH_URL'] = "tcp://localhost:5229"

# ...

logstash_url = URI.parse(ENV['LOGSTASH_URL'])

config = {
  type: logstash_url.scheme.to_sym,
  host: logstash_url.host,
  port: logstash_url.port
}
```

As you can see above `logstash_url.scheme` returns a `String` vs a `Symbol`

This PR will allow users to not have to explicitly convert the type to a `Symbol`

-- Arron
