### PR TITLE
Allow an optional IO object to be used inplace of $stdout

### DIFF
--- a/lib/logstash-logger/device/stdout.rb
+++ b/lib/logstash-logger/device/stdout.rb
@@ -3,7 +3,7 @@ module LogStashLogger
     class Stdout < Base
       def initialize(opts={})
         super
-        @io = $stdout
+        @io = opts[:io] || $stdout
         @io.sync = sync unless sync.nil?
       end
 

--- a/spec/device/stdout_spec.rb
+++ b/spec/device/stdout_spec.rb
@@ -11,4 +11,14 @@ describe LogStashLogger::Device::Stdout do
     expect($stdout).not_to receive(:close)
     subject.close
   end
+
+  context "when io is passed in" do
+    let(:io) { StringIO.new }
+    subject { described_class.new(io: io) }
+
+    it "accepts an optional io object to write to" do
+      expect(subject.to_io).to eq(io)
+      expect{ subject.write("test") }.to change { io.string }.from('').to('test')
+    end
+  end
 end


### PR DESCRIPTION
This is useful for a number of reasons.
1. Testing. Being able to pass in a `StringIO` object and then make assertions on that vs trying to capture output sent to `$stdout` is a lot easier.
2.  I'm working through a codebase where $stdout was overwritten with some other custom logging object. This was painful because when the  `LogstashLogger::Device::Stdout` was created. The `$stdout` global var was already replaced, my solution is to instead pass down the constant `STDOUT` which holds a true reference to `stdout` (until I can eliminate the `$stdout` overriding) 

e.g.

```
LogStashLogger::Device.new(type: :stdout, io: STDOUT)
```

I also plan on submitting a PR with the URI changes we discussed here
https://github.com/dwbutler/logstash-logger/pull/19
just haven't gotten around to it yet. :-)

-- Arron
