### PR TITLE
Default to $stdout with optional override

### DIFF
--- a/lib/logstash-logger/device/stdout.rb
+++ b/lib/logstash-logger/device/stdout.rb
@@ -2,12 +2,12 @@ module LogStashLogger
   module Device
     class Stdout < IO
       def initialize(opts={})
-        super(opts.merge(io: STDOUT))
+        super({io: $stdout}.merge(opts))
       end
 
       def close
         # no-op
-        # Calling STDOUT.close would be a bad idea
+        # Calling $stdout.close would be a bad idea
       end
     end
   end

--- a/spec/device/stdout_spec.rb
+++ b/spec/device/stdout_spec.rb
@@ -1,9 +1,9 @@
 require 'logstash-logger'
 
 describe LogStashLogger::Device::Stdout do
-  let(:stdout) { STDOUT }
+  let(:stdout) { $stdout }
 
-  it "writes to STDOUT" do
+  it "writes to $stdout" do
     expect(subject.to_io).to eq(stdout)
     expect(stdout).to receive(:write).once
     subject.write("test")
@@ -12,5 +12,20 @@ describe LogStashLogger::Device::Stdout do
   it "ignores #close" do
     expect(stdout).not_to receive(:close)
     subject.close
+  end
+
+  context "when the default $stdout has been overridden" do
+    before { $stdout = StringIO.new }
+    after  { $stdout = STDOUT }
+
+    let(:injected_stdout) { STDOUT }
+
+    subject { described_class.new(io: injected_stdout) }
+
+    it "accepts an injectable reference to stdout" do
+      expect(subject.to_io).to eq(injected_stdout)
+      expect(injected_stdout).to receive(:write).once
+      subject.write("test")
+    end
   end
 end


### PR DESCRIPTION
I think the original `$stdout` was definitely a better default, that way people can continue capturing the output using well know ruby idioms.

Most examples of capturing `stdout` essentially look like this.

```
 def capture_stdout
    out = StringIO.new
    $stdout = out
    yield
    return out
  ensure
    $stdout = STDOUT
  end
```

The recent change to use a non-overridable `STDOUT` would force people to redefine the constant, or monkey patch the `LogstashLogger::Device::Stdout` class.

I think this change is the best of both worlds. It has a good default, but remains flexible for people like myself who needs to deal with the fact that somebody has overridden `$stdout`.
