### PR TITLE
Fixing README syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ config.logstash = [
     host: 'localhost'
   }
 ]
+```
 
 ## Ruby Compatibility
 


### PR DESCRIPTION
Thanks for the previous merge!  I realized that there was a missing line from the README, so here's the fix.  Sorry for not catching it sooner.