### PR TITLE
Add app name to logs

### DIFF
--- a/lib/logstash-logger/formatter.rb
+++ b/lib/logstash-logger/formatter.rb
@@ -4,6 +4,7 @@ require 'time'
 
 module LogStashLogger
   HOST = ::Socket.gethostname
+  APPNAME = Rails.application.class.parent_name.titleize
 
   class Formatter < ::Logger::Formatter
     include TaggedLogging::Formatter
@@ -36,7 +37,7 @@ module LogStashLogger
 
       event['host'] ||= HOST
       
-      event['appname'] ||= Rails.application.class.parent_name.titleize
+      event['appname'] ||= APPNAME
 
       current_tags.each do |tag|
         event.tag(tag)

--- a/lib/logstash-logger/formatter.rb
+++ b/lib/logstash-logger/formatter.rb
@@ -35,6 +35,8 @@ module LogStashLogger
       #event.type = progname
 
       event['host'] ||= HOST
+      
+      event['appname'] ||= Rails.application.class.parent_name.titleize
 
       current_tags.each do |tag|
         event.tag(tag)


### PR DESCRIPTION
As far I could tell there was no way to add in an additional field to the logs, other than tagging which isn't right for this problem. I want to be able to log from multiple apps to the same ELK server, and which app is sending the logs is obviously important. I may be missing a more architecturally sound way to do this, however.