### PR TITLE
Buffer connectable log devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ writing to a file or syslog since logstash can receive the structured data direc
 * Events are automatically populated with message, timestamp, host, and severity.
 * Writes in logstash JSON format, but supports other formats as well.
 * Can write to multiple outputs.
-* Log messages are automatically re-sent if there is a connection problem.
+* Log messages are buffered and automatically re-sent if there is a connection problem.
 * Easily integrates with Rails via configuration.
 
 ## Installation
@@ -235,23 +235,26 @@ This configuration would result in the following output.
 }
 ```
 
-## Automatic Retries
+## Buffering / Automatic Retries
 
-Log messages are buffered and automatically re-sent if there is a connection problem. This is
-accomplished using [Stud::Buffer](https://github.com/jordansissel/ruby-stud/blob/master/lib/stud/buffer.rb).
+Log messages are buffered internally, and automatically re-sent if there is a connection problem.
+Outputs that support batch writing (Redis and Kafka) will write log messages in bulk from the
+buffer. This functionality is implemented using
+[Stud::Buffer](https://github.com/jordansissel/ruby-stud/blob/master/lib/stud/buffer.rb).
 You can configure its behavior by passing the following options to LogStashLogger:
 
-    :max_items - Max number of items to buffer before flushing. Default 50.
-    :max_interval - Max number of seconds to wait between flushes. Default 5.
+    :buffer_max_items - Max number of items to buffer before flushing. Defaults to 50.
+    :buffer_max_interval - Max number of seconds to wait between flushes. Defaults to 5.
 
 You can turn this behavior off by setting `max_items` to `1` or `sync` to `true`.
 
 Please be aware of the following caveats to this behavior:
 
- * It's possible for duplicate log messages to be sent when retrying. If this is a problem, you
-   can add a UUID field to the event to uniquely identify it. You can either do this
+ * It's possible for duplicate log messages to be sent when retrying. For outputs like Redis and
+   Kafka that write in batches, the whole batch could get re-sent. If this is a problem, you
+   can add a UUID field to each event to uniquely identify it. You can either do this
    in a `customize_event` block, or by using logstash's
-   [UUID filter](https://www.elastic.co/guide/en/logstash/current/plugins-filters-uuid.html)
+   [UUID filter](https://www.elastic.co/guide/en/logstash/current/plugins-filters-uuid.html).
  * It's still possible to lose log messages. Ruby won't detect a TCP/UDP connection problem
    immediately - in my testing, it took Ruby about 4 seconds to notice the receiving end was down.
    Since logstash listeners over TCP/UDP do not acknowledge received messages, it's not possible
@@ -261,9 +264,9 @@ Please be aware of the following caveats to this behavior:
  * If your application suddenly terminates (for example, by SIGKILL or a power outage), the whole
    buffer will be lost.
 
-You can make message loss and application blockage less likely by increasing `max_items`
-(so that more events can be held in the buffer), and increasing `max_interval` (to wait longer
-between flushes). This will increase memory pressure on your application as log messages
+You can make message loss and application blockage less likely by increasing `buffer_max_items`
+(so that more events can be held in the buffer), and increasing `buffer_max_interval` (to wait
+longer between flushes). This will increase memory pressure on your application as log messages
 accumulate in the buffer, so make sure you have allocated enough memory to your process.
 
 ## Rails Integration
@@ -300,6 +303,12 @@ config.logstash.uri = ENV['LOGSTASH_URI']
 # Optional. Defaults to :json_lines. If there are multiple outputs,
 # they will all share the same formatter.
 config.logstash.formatter = :json_lines
+
+# Optional, max number of items to buffer before flushing. Defaults to 50
+config.logstash.buffer_max_items = 50
+
+# Optional, max number of seconds to wait between flushes. Defaults to 5
+config.logstash.buffer_max_interval = 5
 ```
 
 #### UDP

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ You can configure its behavior by passing the following options to LogStashLogge
     :buffer_max_items - Max number of items to buffer before flushing. Defaults to 50.
     :buffer_max_interval - Max number of seconds to wait between flushes. Defaults to 5.
 
-You can turn this behavior off by setting `max_items` to `1` or `sync` to `true`.
+You can turn this behavior off by setting `buffer_max_items` to `1` or `sync` to `true`.
 
 Please be aware of the following caveats to this behavior:
 
@@ -256,9 +256,9 @@ Please be aware of the following caveats to this behavior:
    in a `customize_event` block, or by using logstash's
    [UUID filter](https://www.elastic.co/guide/en/logstash/current/plugins-filters-uuid.html).
  * It's still possible to lose log messages. Ruby won't detect a TCP/UDP connection problem
-   immediately - in my testing, it took Ruby about 4 seconds to notice the receiving end was down.
-   Since logstash listeners over TCP/UDP do not acknowledge received messages, it's not possible
-   to know which log messages to re-send.
+   immediately. In my testing, it took Ruby about 4 seconds to notice the receiving end was down
+   and start raising exceptions. Since logstash listeners over TCP/UDP do not acknowledge received
+   messages, it's not possible to know which log messages to re-send.
  * If your output source is unavailable long enough, writing to the log will block until it is
    available again. This could make your application unresponsive.
  * If your application suddenly terminates (for example, by SIGKILL or a power outage), the whole

--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ writing to a file or syslog since logstash can receive the structured data direc
 
 ## Features
 
-* Can write directly to logstash over a UDP or TCP/SSL connection.
+* Can write directly to a logstash listener over a UDP or TCP/SSL connection.
 * Can write to a file, Redis, Kafka, a unix socket, syslog, stdout, or stderr.
-* Writes in logstash JSON format, but supports other formats as well.
-* Can write to multiple outputs.
 * Logger can take a string message, a hash, a `LogStash::Event`, an object, or a JSON string as input.
 * Events are automatically populated with message, timestamp, host, and severity.
+* Writes in logstash JSON format, but supports other formats as well.
+* Can write to multiple outputs.
+* Log messages are automatically re-sent if there is a connection problem.
 * Easily integrates with Rails via configuration.
 
 ## Installation
@@ -234,6 +235,36 @@ This configuration would result in the following output.
 }
 ```
 
+## Automatic Retries
+
+Log messages are buffered and automatically re-sent if there is a connection problem. This is
+accomplished using [Stud::Buffer](https://github.com/jordansissel/ruby-stud/blob/master/lib/stud/buffer.rb).
+You can configure its behavior by passing the following options to LogStashLogger:
+
+    :max_items - Max number of items to buffer before flushing. Default 50.
+    :max_interval - Max number of seconds to wait between flushes. Default 5.
+
+You can turn this behavior off by setting `max_items` to `1` or `sync` to `true`.
+
+Please be aware of the following caveats to this behavior:
+
+ * It's possible for duplicate log messages to be sent when retrying. If this is a problem, you
+   can add a UUID field to the event to uniquely identify it. You can either do this
+   in a `customize_event` block, or by using logstash's
+   [UUID filter](https://www.elastic.co/guide/en/logstash/current/plugins-filters-uuid.html)
+ * It's still possible to lose log messages. Ruby won't detect a TCP/UDP connection problem
+   immediately - in my testing, it took Ruby about 4 seconds to notice the receiving end was down.
+   Since logstash listeners over TCP/UDP do not acknowledge received messages, it's not possible
+   to know which log messages to re-send.
+ * If your output source is unavailable long enough, writing to the log will block until it is
+   available again. This could make your application unresponsive.
+ * If your application suddenly terminates (for example, by SIGKILL or a power outage), the whole
+   buffer will be lost.
+
+You can make message loss and application blockage less likely by increasing `max_items`
+(so that more events can be held in the buffer), and increasing `max_interval` (to wait longer
+between flushes). This will increase memory pressure on your application as log messages
+accumulate in the buffer, so make sure you have allocated enough memory to your process.
 
 ## Rails Integration
 

--- a/lib/logstash-logger/device/connectable.rb
+++ b/lib/logstash-logger/device/connectable.rb
@@ -18,11 +18,11 @@ module LogStashLogger
         buffer_flush(force: true) if @sync
       end
 
-      def flush(*messages)
-        if messages.empty?
+      def flush(*args)
+        if args.empty?
           buffer_flush
         else
-          write_batch(messages)
+          write_batch(args[0])
         end
       end
 
@@ -43,7 +43,9 @@ module LogStashLogger
 
       def write_batch(messages)
         with_connection do
-          @io.write(messages.join)
+          messages.each do |message|
+            @io.write(message)
+          end
         end
       end
 

--- a/lib/logstash-logger/device/connectable.rb
+++ b/lib/logstash-logger/device/connectable.rb
@@ -1,17 +1,34 @@
+require 'stud/buffer'
+
 module LogStashLogger
   module Device
     class Connectable < Base
+      include Stud::Buffer
+
+      def initialize(opts = {})
+        super
+        @batch_events = opts[:batch_events] || opts[:max_items]
+        @batch_timeout = opts[:batch_timeout] || opts[:max_interval]
+
+        buffer_initialize max_items: @batch_events, max_interval: @batch_timeout
+      end
+
       def write(message)
-        with_connection do
-          super
+        buffer_receive message
+        buffer_flush(force: true) if @sync
+      end
+
+      def flush(*messages)
+        if messages.empty?
+          buffer_flush
+        else
+          write_batch(messages)
         end
       end
 
-      def flush
-        return unless connected?
-        with_connection do
-          super
-        end
+      def close
+        buffer_flush(final: true)
+        super
       end
 
       def to_io
@@ -24,7 +41,11 @@ module LogStashLogger
         !!@io
       end
 
-      protected
+      def write_batch(messages)
+        with_connection do
+          @io.write(messages.join)
+        end
+      end
 
       # Implemented by subclasses
       def connect
@@ -38,12 +59,12 @@ module LogStashLogger
 
       # Ensure the block is executed with a valid connection
       def with_connection(&block)
-        connect unless @io
+        connect unless connected?
         yield
       rescue => e
         warn "#{self.class} - #{e.class} - #{e.message}"
-        close
         @io = nil
+        raise
       end
     end
   end

--- a/lib/logstash-logger/device/connectable.rb
+++ b/lib/logstash-logger/device/connectable.rb
@@ -7,10 +7,19 @@ module LogStashLogger
 
       def initialize(opts = {})
         super
-        @batch_events = opts[:batch_events] || opts[:max_items]
-        @batch_timeout = opts[:batch_timeout] || opts[:max_interval]
 
-        buffer_initialize max_items: @batch_events, max_interval: @batch_timeout
+        if opts[:batch_events]
+          warn "The :batch_events option is deprecated. Please use :buffer_max_items instead"
+        end
+
+        if opts[:batch_timeout]
+          warn "The :batch_timeout option is deprecated. Please use :buffer_max_interval instead"
+        end
+
+        @buffer_max_items = opts[:batch_events] || opts[:buffer_max_items]
+        @buffer_max_interval = opts[:batch_timeout] || opts[:buffer_max_interval]
+
+        buffer_initialize max_items: @buffer_max_items, max_interval: @buffer_max_interval
       end
 
       def write(message)

--- a/lib/logstash-logger/device/redis.rb
+++ b/lib/logstash-logger/device/redis.rb
@@ -4,8 +4,6 @@ require 'stud/buffer'
 module LogStashLogger
   module Device
     class Redis < Connectable
-      include Stud::Buffer
-
       DEFAULT_LIST = 'logstash'
 
       attr_accessor :list
@@ -14,11 +12,6 @@ module LogStashLogger
         super
         @list = opts.delete(:list) || DEFAULT_LIST
         @redis_options = opts
-
-        @batch_events = opts.fetch(:batch_events, 50)
-        @batch_timeout = opts.fetch(:batch_timeout, 5)
-
-        buffer_initialize max_items: @batch_events, max_interval: @batch_timeout
       end
 
       def connect
@@ -38,6 +31,7 @@ module LogStashLogger
       rescue => e
         warn "#{self.class} - #{e.class} - #{e.message}"
         @io = nil
+        raise
       end
 
       def write(message)
@@ -59,9 +53,13 @@ module LogStashLogger
           buffer_flush
         else
           messages, list = *args
-          with_connection do
-            @io.rpush(list, messages)
-          end
+          write_batch(messages, list)
+        end
+      end
+
+      def write_batch(messages, list = nil)
+        with_connection do
+          @io.rpush(list, messages)
         end
       end
 

--- a/lib/logstash-logger/device/redis.rb
+++ b/lib/logstash-logger/device/redis.rb
@@ -16,7 +16,6 @@ module LogStashLogger
         @redis_options = opts
       end
 
-
       def connect
         @io = ::Redis.new(@redis_options)
       end

--- a/lib/logstash-logger/device/redis.rb
+++ b/lib/logstash-logger/device/redis.rb
@@ -1,5 +1,4 @@
 require 'redis'
-require 'stud/buffer'
 
 module LogStashLogger
   module Device
@@ -39,6 +38,12 @@ module LogStashLogger
         buffer_flush(force: true) if @sync
       end
 
+      def write_batch(messages, list = nil)
+        with_connection do
+          @io.rpush(list, messages)
+        end
+      end
+
       def close
         buffer_flush(final: true)
         @io && @io.quit
@@ -56,13 +61,6 @@ module LogStashLogger
           write_batch(messages, list)
         end
       end
-
-      def write_batch(messages, list = nil)
-        with_connection do
-          @io.rpush(list, messages)
-        end
-      end
-
     end
   end
 end

--- a/lib/logstash-logger/device/tcp.rb
+++ b/lib/logstash-logger/device/tcp.rb
@@ -16,8 +16,6 @@ module LogStashLogger
         @use_ssl || !@ssl_certificate.nil?
       end
 
-      protected
-
       def connect
         if use_ssl?
           ssl_connect
@@ -27,6 +25,8 @@ module LogStashLogger
 
         @io
       end
+
+      protected
 
       def non_ssl_connect
         @io = TCPSocket.new(@host, @port).tap do |socket|

--- a/spec/device/unix_spec.rb
+++ b/spec/device/unix_spec.rb
@@ -7,6 +7,7 @@ describe LogStashLogger::Device::Unix do
 
   before(:each) do
     allow(::UNIXSocket).to receive(:new) { unix_socket }
+    allow(unix_socket).to receive(:sync=)
   end
 
   it "writes to a local unix socket" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,7 @@ RSpec.shared_context 'logger' do
   let(:port) { PORT }
 
   # The logstash logger
-  let(:logger) { LogStashLogger.new(host: host, port: port, type: connection_type) }
+  let(:logger) { LogStashLogger.new(host: host, port: port, type: connection_type, sync: true) }
   # The log device that the logger writes to
   let(:logdev) { logger.instance_variable_get(:@logdev) }
 end
@@ -35,10 +35,10 @@ end
 RSpec.shared_context 'device' do
   let(:port) { PORT }
   let(:device_with_port) { LogStashLogger::Device.new(port: port) }
-  let(:udp_device) { LogStashLogger::Device.new(type: :udp, port: port) }
-  let(:tcp_device) { LogStashLogger::Device.new(type: :tcp, port: port) }
-  let(:ssl_tcp_device) { LogStashLogger::Device.new(type: :tcp, port: port, ssl_enable: true) }
-  let(:unix_device) { LogStashLogger::Device.new(type: :unix, path: '/tmp/logstash') }
+  let(:udp_device) { LogStashLogger::Device.new(type: :udp, port: port, sync: true) }
+  let(:tcp_device) { LogStashLogger::Device.new(type: :tcp, port: port, sync: true) }
+  let(:ssl_tcp_device) { LogStashLogger::Device.new(type: :tcp, port: port, ssl_enable: true, sync: true) }
+  let(:unix_device) { LogStashLogger::Device.new(type: :unix, path: '/tmp/logstash', sync: true) }
 
   let(:file) { Tempfile.new('test') }
   let(:file_device) { LogStashLogger::Device.new(type: :file, path: file.path)}


### PR DESCRIPTION
This throws connectable log devices (such as TCP, UDP, and Redis) behind `Stud::Buffer` in an attempt to improve reliability. In my testing, I have verified that log messages do get buffered, and will retry if an exception is thrown.

However, I have found that sockets don't always raise an exception right away when the server side of the socket is closed. See http://stackoverflow.com/questions/2530652/ruby-tcpsocket-doesnt-notice-it-when-server-is-killed and https://www.ruby-forum.com/topic/148532. This means that some messages will inevitably get lost. Logstash does not return any sort of reply to acknowledge that it received the message, so it's impossible to tell if the message was sent successfully if no exception is raised.

Log messages are written out one at a time. This way, if an exception is raised, the whole batch of messages is retried, and messages are less likely to be lost. However, this does result in duplicate log messages being delivered. Logstash's [uuid filter](https://www.elastic.co/guide/en/logstash/current/plugins-filters-uuid.html) looks like a promising way of dealing with duplicate log messages.