### PR TITLE
Add handling of path option in redis client

### DIFF
--- a/lib/logstash-logger/device/redis.rb
+++ b/lib/logstash-logger/device/redis.rb
@@ -13,6 +13,9 @@ module LogStashLogger
       def initialize(opts)
         super
         @list = opts.delete(:list) || DEFAULT_LIST
+
+        normalize_path(opts)
+
         @redis_options = opts
 
         @batch_events = opts.fetch(:batch_events, 50)
@@ -20,6 +23,7 @@ module LogStashLogger
 
         buffer_initialize max_items: @batch_events, max_interval: @batch_timeout
       end
+
 
       def connect
         @io = ::Redis.new(@redis_options)
@@ -62,6 +66,16 @@ module LogStashLogger
           with_connection do
             @io.rpush(list, messages)
           end
+        end
+      end
+      
+      private
+
+      def normalize_path(opts)
+        path = opts.fetch(:path, nil)
+        if path
+          opts[:db] = path.gsub("/", "").to_i unless path.empty?
+          opts.delete(:path)
         end
       end
 

--- a/spec/device/redis_spec.rb
+++ b/spec/device/redis_spec.rb
@@ -19,4 +19,34 @@ describe LogStashLogger::Device::Redis do
   it "defaults the Redis list to 'logstash'" do
     expect(redis_device.list).to eq('logstash')
   end
+
+  describe "initializer" do
+    let(:redis_options) { { host: HOST, port: 6379 } }
+    subject { LogStashLogger::Device::Redis.new(redis_options).connect }
+
+    context "path is not blank" do
+      before do
+        redis_options[:path] = "/0"
+      end
+
+      it "sets the db" do
+        expect(Redis).to receive(:new).with(hash_including(db: 0))
+        subject
+      end
+
+    end
+
+    context "path is blank" do
+      before do
+        redis_options[:path] = ""
+      end
+
+      it "does not set the db" do
+        expect(Redis).to receive(:new).with(hash_excluding(:db))
+        subject
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION
The URI parser puts a path param into the options hash, this is not handled correctly by the redis client.
This is a fix for issue #41 