### PR TITLE
Added cee formatter.

### DIFF
--- a/lib/logstash-logger/cee_formatter.rb
+++ b/lib/logstash-logger/cee_formatter.rb
@@ -1,0 +1,11 @@
+require 'logger'
+require 'logstash-logger/formatter'
+
+module LogStashLogger
+  class CeeFormatter < LogStashLogger::Formatter
+    def call(severity, time, progname, message)
+      event = build_event(message, severity, time)
+      "#{event['host']} #{progname}:@cee: #{event.to_json}\n"
+    end
+  end
+end


### PR DESCRIPTION
This creates a CEE style formatter which can be used with syslog-ng, and other devices that take logs in CEE format.

I'm using it in conjunction with a service from here:  https://apps.sematext.com

With this configuration:  
```
LogStashLogger.configure do | logconfig| 
  logconfig.customize_event do | event|
    event["logsene-app-token"]= ENV['logsene_app_token']
  end
end
config.logger = LogStashLogger.new(type: :tcp, host: 'logsene-receiver-syslog.sematext.com', port: 514)
config.logger.formatter = LogStashLogger::CeeFormatter.new 
```

It works great.