### PR TITLE
fix to allow configuration of other values via uri

### DIFF
--- a/lib/logstash-logger/device.rb
+++ b/lib/logstash-logger/device.rb
@@ -35,7 +35,8 @@ module LogStashLogger
 
     def self.build_device(opts)
       if parsed_uri_opts = parse_uri_config(opts)
-        opts = parsed_uri_opts
+        opts.delete(:uri)
+        opts.merge!(parsed_uri_opts)
       end
 
       type = opts.delete(:type) || DEFAULT_TYPE

--- a/spec/device_spec.rb
+++ b/spec/device_spec.rb
@@ -70,6 +70,12 @@ describe LogStashLogger::Device do
     context "when URI config is redis" do
       let(:uri_config) { redis_uri_config }
       it { is_expected.to be_a LogStashLogger::Device::Redis }
+      context "list specified" do
+        let(:uri_config) { redis_uri_config.merge({list: 'mylist'}) }
+        it 'is expected to have the list option set' do
+          expect(new_device.list).to eq('mylist')
+        end
+      end
     end
 
     context "when URI config is kafka" do


### PR DESCRIPTION
previously any non uri options passed to a device would be stripped out. This makes the behavior consistent with how the Rails configuration works.