### PR TITLE
Support for multiple loggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,24 +77,24 @@ ruby_default_formatter_logger = LogStashLogger.new(
 multi_delegating_logger = LogStashLogger.new(
   type: :multi_delegator,
   outputs: [
-    {type: :file, path: 'log/development.log'},
-    {type: :udp, host: 'localhost', port: 5228}
+    { type: :file, path: 'log/development.log' },
+    { type: :udp, host: 'localhost', port: 5228 }
   ])
 
 # Balance messages between several devices
 balancer_logger = LogStashLogger.new(
   type: :balancer,
   outputs: [
-    {type: :udp, host: 'host1', port: 5228},
-    {type: :udp, host: 'host2', port: 5228}
+    { type: :udp, host: 'host1', port: 5228 },
+    { type: :udp, host: 'host2', port: 5228 }
   ])
 
 # Send the message to multiple loggers. Each logger can have a different format.
 multi_logger = LogStashLogger.new(
   type: :multi_logger,
   outputs: [
-    {type: :file, path: 'log/development.log', formatter: ::Logger::Formatter},
-    {type: :tcp, host: 'localhost', port: 5228, formatter: :json}
+    { type: :file, path: 'log/development.log', formatter: ::Logger::Formatter },
+    { type: :tcp, host: 'localhost', port: 5228, formatter: :json }
   ])
 
 # The following messages are written to UDP port 5228:
@@ -379,6 +379,7 @@ config.logstash.type = :multi_delegator
 
 # Required
 config.logstash.outputs = [
+  {
     type: :file,
     path: 'log/production.log'
   },
@@ -398,6 +399,7 @@ config.logstash.type = :multi_logger
 
 # Required. Each logger may have its own formatter.
 config.logstash.outputs = [
+  {
     type: :file,
     path: 'log/production.log',
     formatter: ::Logger::Formatter
@@ -525,6 +527,7 @@ logger = LogStashLogger.new('localhost', 5228, :tcp)
 * [Anil Rhemtulla](https://github.com/AnilRh)
 * [Nikita Vorobei](https://github.com/Nikita-V)
 * [fireboy1919](https://github.com/fireboy1919)
+* [ffmike](https://github.com/ffmike)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ writing to a file or syslog since logstash can receive the structured data direc
 * Can write directly to logstash over a UDP or TCP/SSL connection.
 * Can write to a file, Redis, a unix socket, stdout or stderr.
 * Writes in logstash JSON format, but supports other formats as well.
+* Can write to multiple outputs.
 * Logger can take a string message, a hash, a `LogStash::Event`, an object, or a JSON string as input.
 * Events are automatically populated with message, timestamp, host, and severity.
 * Easily integrates with Rails via configuration.
@@ -410,6 +411,7 @@ config.logstash.outputs = [
     host: 'localhost'
   }
 ]
+```
 
 ### Logging HTTP request data
 
@@ -527,7 +529,7 @@ logger = LogStashLogger.new('localhost', 5228, :tcp)
 * [Anil Rhemtulla](https://github.com/AnilRh)
 * [Nikita Vorobei](https://github.com/Nikita-V)
 * [fireboy1919](https://github.com/fireboy1919)
-* [ffmike](https://github.com/ffmike)
+* [Mike Gunderloy](https://github.com/ffmike)
 
 ## Contributing
 

--- a/lib/logstash-logger/device.rb
+++ b/lib/logstash-logger/device.rb
@@ -21,17 +21,7 @@ module LogStashLogger
 
     def self.new(opts)
       opts = opts.dup
-
-      if opts.is_a?(Array)
-        # Multiple device configs supplied... create a MultiDelegator
-        devices = opts.map{|opt| build_device(opt)}
-        Device::MultiDelegator.new(*devices)
-      elsif Hash
-        # Create a single device
-        build_device(opts)
-      else
-        raise ArgumentError, "Invalid device options: must be a Hash or an Array of Hashes"
-      end
+      build_device(opts)
     end
 
     def self.build_device(opts)
@@ -63,8 +53,9 @@ module LogStashLogger
         when :io then IO
         when :stdout then Stdout
         when :stderr then Stderr
+        when :multi_delegator then MultiDelegator
         when :balancer then Balancer
-        else fail ArgumentError, 'Invalid type'
+        else fail ArgumentError, 'Invalid device type'
       end
     end
   end

--- a/lib/logstash-logger/device/balancer.rb
+++ b/lib/logstash-logger/device/balancer.rb
@@ -13,7 +13,7 @@ module LogStashLogger
       private
 
       def create_devices(opts)
-        opts.map { |o| Device.new(o) }
+        opts.map { |device_opts| Device.new(device_opts) }
       end
 
       def self.delegate_to_all(*methods)

--- a/lib/logstash-logger/device/multi_delegator.rb
+++ b/lib/logstash-logger/device/multi_delegator.rb
@@ -8,13 +8,19 @@ module LogStashLogger
     class MultiDelegator < Base
       attr_reader :devices
 
-      def initialize(*devices)
+      def initialize(opts)
         @io = self
-        @devices = devices
+        @devices = create_devices(opts[:outputs])
         self.class.delegate(:write, :close, :flush)
       end
 
       private
+
+      def create_devices(opts)
+        opts.map do |device_opts|
+          Device.new(device_opts)
+        end
+      end
 
       def self.delegate(*methods)
         methods.each do |m|

--- a/lib/logstash-logger/formatter.rb
+++ b/lib/logstash-logger/formatter.rb
@@ -17,13 +17,16 @@ module LogStashLogger
     def self.build_formatter(formatter_type)
       formatter_type ||= DEFAULT_FORMATTER
 
-      if custom_formatter_instance?(formatter_type)
+      formatter = if custom_formatter_instance?(formatter_type)
         formatter_type
       elsif custom_formatter_class?(formatter_type)
         formatter_type.new
       else
         formatter_klass(formatter_type).new
       end
+
+      formatter.send(:extend, ::LogStashLogger::TaggedLogging::Formatter)
+      formatter
     end
 
     def self.formatter_klass(formatter_type)

--- a/lib/logstash-logger/logger.rb
+++ b/lib/logstash-logger/logger.rb
@@ -2,17 +2,11 @@ require 'logger'
 require 'logstash-logger/tagged_logging'
 
 module LogStashLogger
+  autoload :MultiLogger, 'logstash-logger/multi_logger'
+
   def self.new(*args)
     opts = extract_opts(*args)
-    formatter = Formatter.new(opts.delete(:formatter))
-    device = Device.new(opts)
-
-    ::Logger.new(device).tap do |logger|
-      logger.instance_variable_set(:@device, device)
-      logger.extend(self)
-      logger.extend(TaggedLogging)
-      logger.formatter = formatter
-    end
+    build_logger(opts)
   end
 
   def self.extended(base)
@@ -34,18 +28,37 @@ module LogStashLogger
 
     if args.length > 1
       if args.all?{|arg| arg.is_a?(Hash)}
-        # Array of Hashes
-        args
+        # Deprecated array of hashes
+        warn "[LogStashLogger] Passing an array of hashes to the constructor is deprecated. Please replace with an options hash: { type: :multi_delegator, outputs: [...] }"
+        { type: :multi_delegator, outputs: args }
       else
-        # Deprecated host/port/type syntax
-        puts "[LogStashLogger] (host, port, type) constructor is deprecated. Please use an options hash instead."
+        # Deprecated host/port/type constructor
+        warn "[LogStashLogger] The (host, port, type) constructor is deprecated. Please use an options hash instead."
         host, port, type = *args
-        {host: host, port: port, type: type}
+        { host: host, port: port, type: type }
       end
     elsif Hash === args[0]
       args[0]
     else
       fail ArgumentError, "Invalid LogStashLogger options"
+    end
+  end
+
+  def self.build_logger(opts)
+    case opts[:type]
+    when :multi_logger
+      loggers = opts[:outputs].map {|logger_opts| build_logger(logger_opts) }
+      MultiLogger.new(loggers)
+    else
+      formatter = Formatter.new(opts.delete(:formatter))
+      device = Device.new(opts)
+
+      ::Logger.new(device).tap do |logger|
+        logger.instance_variable_set(:@device, device)
+        logger.extend(self)
+        logger.extend(TaggedLogging)
+        logger.formatter = formatter
+      end
     end
   end
 end

--- a/lib/logstash-logger/logger.rb
+++ b/lib/logstash-logger/logger.rb
@@ -16,7 +16,7 @@ module LogStashLogger
       end
 
       def flush
-        !!@device.flush
+        !!(@device.flush if @device.respond_to?(:flush))
       end
     end
   end

--- a/lib/logstash-logger/multi_logger.rb
+++ b/lib/logstash-logger/multi_logger.rb
@@ -114,5 +114,22 @@ module LogStashLogger
         logger.close if logger.respond_to?(:close)
       end
     end
+
+    module TaggedLogging
+      def tagged(*tags)
+        @loggers.each do |logger|
+          logger.formatter.tagged(*tags) { yield self }
+        end
+      end
+
+      def flush
+        @loggers.each do |logger|
+          logger.formatter.clear_tags!
+        end
+        super if defined?(super)
+      end
+    end
+
+    include TaggedLogging
   end
 end

--- a/lib/logstash-logger/multi_logger.rb
+++ b/lib/logstash-logger/multi_logger.rb
@@ -1,0 +1,117 @@
+# Adapted from https://github.com/ffmike/multilogger
+module LogStashLogger
+  class MultiLogger < ::Logger
+    def level=(value)
+      super
+      @loggers.each do |logger|
+        logger.level = value
+      end
+    end
+
+    def progname=(value)
+      super
+      @loggers.each do |logger|
+        logger.progname = value
+      end
+    end
+
+    def datetime_format=(datetime_format)
+      super
+      @loggers.each do |logger|
+        logger.datetime_format = datetime_format
+      end
+    end
+
+    def formatter=(formatter)
+      @loggers.each do |logger|
+        logger.formatter = formatter
+      end
+    end
+
+    # Array of Loggers to be logged to. These can be anything that acts reasonably like a Logger.
+    attr_accessor :loggers
+
+    # Any method not defined on standard Logger class, just send it on to anyone who will listen
+    def method_missing(name, *args, &block)
+      @loggers.each do |logger|
+        if logger.respond_to?(name)
+          logger.send(name, args, &block)
+        end
+      end
+    end
+
+    #
+    # === Synopsis
+    #
+    #   MultiLogger.new([logger1, logger2])
+    #
+    # === Args
+    #
+    # +loggers+::
+    #   An array of loggers. Each one gets every message that is sent to the MultiLogger instance
+    #
+    # === Description
+    #
+    # Create an instance.
+    #
+    def initialize(loggers)
+      super(nil)
+      @loggers = Array(loggers)
+    end
+
+    # Methods that write to logs just write to each contained logger in turn
+    def add(severity, message = nil, progname = nil, &block)
+      @loggers.each do |logger|
+        logger.add(severity, message, progname, &block)
+      end
+    end
+
+    def <<(msg)
+      @loggers.each do |logger|
+        logger << msg
+      end
+    end
+
+    def debug(progname = nil, &block)
+      @loggers.each do |logger|
+        logger.debug(progname, &block)
+      end
+    end
+
+    def info(progname = nil, &block)
+      @loggers.each do |logger|
+        logger.info(progname, &block)
+      end
+    end
+
+    def warn(progname = nil, &block)
+      @loggers.each do |logger|
+        logger.warn(progname, &block)
+      end
+    end
+
+    def error(progname = nil, &block)
+      @loggers.each do |logger|
+        logger.error(progname, &block)
+      end
+    end
+
+    def fatal(progname = nil, &block)
+      @loggers.each do |logger|
+        logger.fatal(progname, &block)
+      end
+    end
+
+    def unknown(progname = nil, &block)
+      @loggers.each do |logger|
+        logger.unknown(progname, &block)
+      end
+    end
+
+    def close
+      @loggers.each do |logger|
+        logger.close if logger.respond_to?(:close)
+      end
+    end
+  end
+end

--- a/lib/logstash-logger/multi_logger.rb
+++ b/lib/logstash-logger/multi_logger.rb
@@ -55,6 +55,7 @@ module LogStashLogger
     # Create an instance.
     #
     def initialize(loggers)
+      @loggers = []
       super(nil)
       @loggers = Array(loggers)
     end

--- a/logstash-logger.gemspec
+++ b/logstash-logger.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rails'
   gem.add_development_dependency 'redis'
   gem.add_development_dependency 'poseidon'
+
   gem.add_development_dependency 'rspec', '>= 3'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'pry'

--- a/spec/device/balancer_spec.rb
+++ b/spec/device/balancer_spec.rb
@@ -6,9 +6,6 @@ describe LogStashLogger::Device::Balancer do
   # Create a Balancer writing to both STDOUT and a StringIO
   let(:subject) { balancer_device }
 
-  let(:stdout) { $stdout }
-  let(:io) { StringIO.new }
-
   describe '#write' do
     before do
       allow(subject.devices).to receive(:sample) { io }
@@ -16,7 +13,7 @@ describe LogStashLogger::Device::Balancer do
 
     it "writes to one device" do
       expect(io).to receive(:write).once
-      expect(stdout).to_not receive(:write)
+      expect($stdout).to_not receive(:write)
       subject.write("log message")
     end
   end

--- a/spec/device/balancer_spec.rb
+++ b/spec/device/balancer_spec.rb
@@ -4,7 +4,7 @@ describe LogStashLogger::Device::Balancer do
   include_context 'device'
 
   # Create a Balancer writing to both STDOUT and a StringIO
-  let(:subject) { balancer_device }
+  subject { balancer_device }
 
   describe '#write' do
     before do

--- a/spec/device/file_spec.rb
+++ b/spec/device/file_spec.rb
@@ -9,7 +9,7 @@ describe LogStashLogger::Device::File do
 
   context "when path is not specified" do
     it "raises an exception" do
-      expect { described_class.new }.to raise_error
+      expect { described_class.new }.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/device/io_spec.rb
+++ b/spec/device/io_spec.rb
@@ -3,8 +3,7 @@ require 'logstash-logger'
 describe LogStashLogger::Device::IO do
   include_context 'device'
 
-  let(:subject) { io_device }
-  let(:io) { StringIO.new }
+  subject { io_device }
 
   it "writes to the IO object" do
     expect(subject.to_io).to eq(io)

--- a/spec/device/multi_delegator_spec.rb
+++ b/spec/device/multi_delegator_spec.rb
@@ -4,7 +4,7 @@ describe LogStashLogger::Device::MultiDelegator do
   include_context 'device'
 
   # Create a MultiDelegator writing to both STDOUT and a StringIO
-  let(:subject) { multi_delegator_device }
+  subject { multi_delegator_device }
 
   it "writes to all outputs" do
     expect($stdout).to receive(:write).once

--- a/spec/device/multi_delegator_spec.rb
+++ b/spec/device/multi_delegator_spec.rb
@@ -6,14 +6,8 @@ describe LogStashLogger::Device::MultiDelegator do
   # Create a MultiDelegator writing to both STDOUT and a StringIO
   let(:subject) { multi_delegator_device }
 
-  let(:stdout) { $stdout }
-  let(:io) { StringIO.new }
-
-  it "writes to $stdout" do
-    # MultiDelegator writes to stdout
-    expect(stdout).to receive(:write).once
-
-    # MultiDelegator writes to IO
+  it "writes to all outputs" do
+    expect($stdout).to receive(:write).once
     expect(io).to receive(:write).once
 
     subject.write("test")

--- a/spec/device/socket_spec.rb
+++ b/spec/device/socket_spec.rb
@@ -9,7 +9,7 @@ describe LogStashLogger::Device::Socket do
 
   context "when port is not specified" do
     it "raises an exception" do
-      expect { described_class.new }.to raise_error
+      expect { described_class.new }.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/device/unix_spec.rb
+++ b/spec/device/unix_spec.rb
@@ -16,7 +16,7 @@ describe LogStashLogger::Device::Unix do
 
   context "when path is not specified" do
     it "raises an exception" do
-      expect { described_class.new }.to raise_error
+      expect { described_class.new }.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/device_spec.rb
+++ b/spec/device_spec.rb
@@ -40,7 +40,7 @@ describe LogStashLogger::Device do
 
     context "when uri is invalid" do
       let(:uri_config) { invalid_uri_config }
-      specify { expect{ parse_uri_config }.to raise_error(URI::InvalidURIError) }
+      specify { expect { parse_uri_config }.to raise_error(URI::InvalidURIError) }
     end
   end
 

--- a/spec/formatter_spec.rb
+++ b/spec/formatter_spec.rb
@@ -25,27 +25,54 @@ describe LogStashLogger::Formatter do
     end
 
     context "custom formatter" do
-      it "returns a new instance of a custom formatter class" do
-        expect(described_class.new(::Logger::Formatter)).to be_a ::Logger::Formatter
-      end
+      subject { described_class.new(formatter) }
 
-      it "returns the same formatter instance if a custom formatter instance is passed in" do
-        formatter = ::Logger::Formatter.new
-        expect(described_class.new(formatter)).to eql(formatter)
-      end
+      context "formatter class" do
+        let(:formatter) { ::Logger::Formatter }
 
-      it "returns a formatter proc if it is passed in" do
-        formatter = proc do |severity, time, progname, msg|
-          msg
+        it "returns a new instance of the class" do
+          expect(subject).to be_a formatter
         end
-        expect(described_class.new(formatter)).to eql(formatter)
       end
 
-      it "returns a formatter lambda if it is passed in" do
-        formatter = lambda do |severity, time, progname, msg|
-          msg
+      context "formatter instance" do
+        let(:formatter) { ::Logger::Formatter.new }
+
+        it "returns the same formatter instance" do
+          expect(subject).to eql(formatter)
         end
-        expect(described_class.new(formatter)).to eql(formatter)
+
+        it "supports tagged logging" do
+          expect(subject).to be_a ::LogStashLogger::TaggedLogging::Formatter
+        end
+      end
+
+      context "formatter proc" do
+        let(:formatter) do
+          proc { |severity, time, progname, msg| msg }
+        end
+
+        it "returns the same formatter proc" do
+          expect(subject).to eql(formatter)
+        end
+
+        it "supports tagged logging" do
+          expect(subject).to be_a ::LogStashLogger::TaggedLogging::Formatter
+        end
+      end
+
+      context "formatter lambda" do
+        let(:formatter) do
+          ->(severity, time, progname, msg) { msg }
+        end
+
+        it "returns the same formatter lambda" do
+          expect(subject).to eql(formatter)
+        end
+
+        it "supports tagged logging" do
+          expect(subject).to be_a ::LogStashLogger::TaggedLogging::Formatter
+        end
       end
     end
   end

--- a/spec/multi_logger_spec.rb
+++ b/spec/multi_logger_spec.rb
@@ -1,0 +1,32 @@
+require 'logstash-logger'
+
+describe LogStashLogger::MultiLogger do
+  include_context 'device'
+
+  # Create a MultiLogger writing to both STDOUT and a StringIO
+  let(:subject) { multi_logger }
+
+  it { is_expected.to be_a LogStashLogger::MultiLogger }
+
+  it "has multiple loggers" do
+    expect(subject.loggers.count).to eq(2)
+  end
+
+  it "has one logger per output" do
+    expect(subject.loggers[0].device).to be_a LogStashLogger::Device::Stdout
+    expect(subject.loggers[1].device).to be_a LogStashLogger::Device::IO
+  end
+
+  it "allows a different formatter for each logger" do
+    expect(subject.loggers[0].formatter).to be_a ::Logger::Formatter
+    expect(subject.loggers[1].formatter).to be_a LogStashLogger::Formatter::JsonLines
+  end
+
+  it "logs to all loggers" do
+    subject.loggers.each do |logger|
+      expect(logger).to receive(:info).with("test")
+    end
+
+    multi_logger.info("test")
+  end
+end

--- a/spec/multi_logger_spec.rb
+++ b/spec/multi_logger_spec.rb
@@ -4,7 +4,7 @@ describe LogStashLogger::MultiLogger do
   include_context 'device'
 
   # Create a MultiLogger writing to both STDOUT and a StringIO
-  let(:subject) { multi_logger }
+  subject { multi_logger }
 
   it { is_expected.to be_a LogStashLogger::MultiLogger }
 
@@ -28,5 +28,25 @@ describe LogStashLogger::MultiLogger do
     end
 
     multi_logger.info("test")
+  end
+
+  context "tagged logging" do
+    it "forwards tags to each logger's formatter" do
+      subject.loggers.each do |logger|
+        expect(logger.formatter).to receive(:tagged).with("foo")
+      end
+
+      subject.tagged("foo") do |logger|
+        logger.debug("bar")
+      end
+    end
+
+    it "clears tags on each logger's formatter when flushing" do
+      subject.loggers.each do |logger|
+        expect(logger.formatter).to receive(:clear_tags!)
+      end
+
+      subject.flush
+    end
   end
 end

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -52,21 +52,23 @@ describe LogStashLogger do
         end
       end
 
-      context "when configured with multiple devices" do
+      context "when configuring a multi delegator" do
         before(:each) do
-          app.config.logstash = [
+          app.config.logstash.type = :multi_delegator
+          app.config.logstash.outputs = [
             {
               type: :udp,
               uri: udp_uri
             },
             {
-              type: :file
+              type: :file,
+              path: '/tmp/foo.log'
             }
           ]
           LogStashLogger.setup(app)
         end
 
-        it "uses a multi-delegator" do
+        it "uses a multi delegator" do
           expect(subject.device).to be_a LogStashLogger::Device::MultiDelegator
           expect(subject.device.devices.map(&:class)).to eq([
             LogStashLogger::Device::UDP,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -56,12 +56,24 @@ RSpec.shared_context 'device' do
   let(:file) { Tempfile.new('test') }
   let(:file_device) { LogStashLogger::Device.new(type: :file, path: file.path)}
 
+  let(:io) { StringIO.new }
   let(:io_device) { LogStashLogger::Device.new(type: :io, io: io)}
 
   let(:redis_device) { LogStashLogger::Device.new(type: :redis, sync: true) }
   let(:kafka_device) { LogStashLogger::Device.new(type: :kafka, sync: true) }
-  let(:multi_delegator_device) { LogStashLogger::Device.new([{type: :stdout}, {type: :io, io: io}]) }
-  let(:balancer_device) { LogStashLogger::Device.new(type: :balancer, outputs: [{type: :stdout}, {type: :io, io: io}]) }
+
+  let(:outputs) { [{type: :stdout}, {type: :io, io: io}] }
+  let(:multi_delegator_device) { LogStashLogger::Device.new(type: :multi_delegator, outputs: outputs) }
+  let(:balancer_device) { LogStashLogger::Device.new(type: :balancer, outputs: outputs) }
+  let(:multi_logger) do
+    LogStashLogger.new(
+        type: :multi_logger,
+        outputs: [
+            { type: :stdout, formatter: ::Logger::Formatter },
+            { type: :io, io: io }
+        ]
+    )
+  end
 
   let(:udp_uri) { "udp://localhost:5228" }
   let(:tcp_uri) { "tcp://localhost:5229" }


### PR DESCRIPTION
The new `:multi_logger` type writes log messages to multiple loggers. Each logger can have its own formatter.

Fixes #52