### PR TITLE
Support for logging to syslog

### DIFF
--- a/logstash-logger.gemspec
+++ b/logstash-logger.gemspec
@@ -25,6 +25,10 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'redis'
   gem.add_development_dependency 'poseidon'
 
+  if RUBY_VERSION < '2'
+    gem.add_development_dependency 'SyslogLogger'
+  end
+
   gem.add_development_dependency 'rspec', '>= 3'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'pry'

--- a/samples/syslog.conf
+++ b/samples/syslog.conf
@@ -1,0 +1,10 @@
+input {
+  syslog {
+    codec => json_lines
+  }
+}
+output {
+  stdout {
+    codec => json_lines
+  }
+}

--- a/spec/syslog_spec.rb
+++ b/spec/syslog_spec.rb
@@ -1,0 +1,25 @@
+require 'logstash-logger'
+
+describe LogStashLogger do
+  context "Syslog" do
+    let(:program_name) { "MyApp" }
+    let(:facility) { Syslog::LOG_LOCAL0 }
+    subject { LogStashLogger.new(type: :syslog, program_name: program_name, facility: facility) }
+    let(:syslog) { subject.class.class_variable_get(:@@syslog) }
+
+    it { is_expected.to be_a Syslog::Logger }
+
+    it "writes formatted messages to syslog" do
+      expect(syslog).to receive(:log)
+      subject.info("test")
+    end
+
+    it "sets the syslog identity" do
+      expect(syslog.ident).to eq(program_name)
+    end
+
+    it "sets the default facility if supported" do
+      expect(subject.facility).to eq(facility) if subject.respond_to?(:facility)
+    end
+  end
+end


### PR DESCRIPTION
This uses `Syslog::Logger`, which is built into the Ruby 2+ standard library, and available as a separate gem in Ruby 1.9. Note that this is a separate logger rather than a device.

Fixes #50