### PR TITLE
Prevent formatter of each logger in MultiLogger from being overridden with the default

### DIFF
--- a/lib/logstash-logger/multi_logger.rb
+++ b/lib/logstash-logger/multi_logger.rb
@@ -24,7 +24,7 @@ module LogStashLogger
 
     def formatter=(formatter)
       @loggers.each do |logger|
-        logger.formatter = formatter
+        logger.formatter ||= formatter
       end
     end
 

--- a/spec/multi_logger_spec.rb
+++ b/spec/multi_logger_spec.rb
@@ -18,8 +18,8 @@ describe LogStashLogger::MultiLogger do
   end
 
   it "allows a different formatter for each logger" do
-    expect(subject.loggers[0].formatter).to be_a ::Logger::Formatter
-    expect(subject.loggers[1].formatter).to be_a LogStashLogger::Formatter::JsonLines
+    expect(subject.loggers[0].formatter.class).to eq ::Logger::Formatter
+    expect(subject.loggers[1].formatter.class).to eq LogStashLogger::Formatter::JsonLines
   end
 
   it "logs to all loggers" do


### PR DESCRIPTION
Fixes #61