### PR TITLE
Fix configuration on Windows

### DIFF
--- a/lib/logstash-logger/logger.rb
+++ b/lib/logstash-logger/logger.rb
@@ -1,11 +1,6 @@
 require 'logger'
 require 'logstash-logger/tagged_logging'
 
-autoload :Syslog, 'syslog'
-module Syslog
-  autoload :Logger, 'syslog/logger'
-end
-
 module LogStashLogger
   autoload :MultiLogger, 'logstash-logger/multi_logger'
 
@@ -83,6 +78,8 @@ module LogStashLogger
 
   def self.build_syslog_logger(opts)
     logger = begin
+      require 'syslog/logger'
+
       Syslog::Logger.new(opts[:program_name], opts[:facility])
     rescue ArgumentError
       Syslog::Logger.new(opts[:program_name])

--- a/spec/syslog_spec.rb
+++ b/spec/syslog_spec.rb
@@ -3,7 +3,7 @@ require 'logstash-logger'
 describe LogStashLogger do
   context "Syslog" do
     let(:program_name) { "MyApp" }
-    let(:facility) { Syslog::LOG_LOCAL0 }
+    let(:facility) { 128 } #Syslog::LOG_LOCAL0 }
     subject { LogStashLogger.new(type: :syslog, program_name: program_name, facility: facility) }
     let(:syslog) { subject.class.class_variable_get(:@@syslog) }
 


### PR DESCRIPTION
Syslog is unavailable on Windows. Autoloading Syslog is therefore a bad idea, since this results in a LoadError if the Syslog constant is ever referenced on a Windows machine.

Fixes #64