### PR TITLE
security: Verify SSL certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,14 @@ You can also enable SSL without a certificate:
 LogStashLogger.new(type: :tcp, port: 5228, ssl_enable: true)
 ```
 
+You can also specify an SSL context. This can be used to disable host verification.
+
+```ruby
+ctx = OpenSSL::SSL::SSLContext.new
+ctx.set_params(verify_mode: OpenSSL::SSL::VERIFY_NONE)
+LogStashLogger.new(type: :tcp, port: 5228, ssl_enable: true, ssl_context: ctx)
+```
+
 The following Logstash configuration is required for SSL:
 
 ```ruby

--- a/lib/logstash-logger/device/tcp.rb
+++ b/lib/logstash-logger/device/tcp.rb
@@ -10,7 +10,7 @@ module LogStashLogger
 
         @ssl_certificate = opts[:ssl_certificate]
         @use_ssl = !!(@ssl_certificate || opts[:use_ssl] || opts[:ssl_enable])
-        @ssl_context = opts.fetch(:ssl_context, OpenSSL::SSL::SSLContext.new)
+        @ssl_context = opts.fetch(:ssl_context, nil)
       end
 
       def use_ssl?
@@ -38,9 +38,15 @@ module LogStashLogger
       def ssl_connect
         non_ssl_connect
         #openssl_cert = OpenSSL::X509::Certificate.new(::File.read(@ssl_certificate))
-        @io = OpenSSL::SSL::SSLSocket.new(@io, @ssl_context)
-        @io.connect
-        @io.post_connection_check(@host)
+        if @ssl_context
+          @io = OpenSSL::SSL::SSLSocket.new(@io, @ssl_context)
+          @io.connect
+          @io.post_connection_check(@host)
+        else
+          warn "[DEPRECATION] 'LogStashLogger::Device::Socket' should be instantiated with a SSL context for hostname verification."
+          @io = OpenSSL::SSL::SSLSocket.new(@io)
+          @io.connect
+        end
       end
     end
   end

--- a/lib/logstash-logger/device/tcp.rb
+++ b/lib/logstash-logger/device/tcp.rb
@@ -10,6 +10,7 @@ module LogStashLogger
 
         @ssl_certificate = opts[:ssl_certificate]
         @use_ssl = !!(@ssl_certificate || opts[:use_ssl] || opts[:ssl_enable])
+        @ssl_context = opts.fetch(:ssl_context, nil)
       end
 
       def use_ssl?
@@ -37,7 +38,7 @@ module LogStashLogger
       def ssl_connect
         non_ssl_connect
         #openssl_cert = OpenSSL::X509::Certificate.new(::File.read(@ssl_certificate))
-        @io = OpenSSL::SSL::SSLSocket.new(@io)
+        @io = OpenSSL::SSL::SSLSocket.new(@io, @ssl_context)
         @io.connect
         @io.post_connection_check(@host)
       end

--- a/lib/logstash-logger/device/tcp.rb
+++ b/lib/logstash-logger/device/tcp.rb
@@ -39,6 +39,7 @@ module LogStashLogger
         #openssl_cert = OpenSSL::X509::Certificate.new(::File.read(@ssl_certificate))
         @io = OpenSSL::SSL::SSLSocket.new(@io)
         @io.connect
+        @io.post_connection_check(@host)
       end
     end
   end

--- a/lib/logstash-logger/device/tcp.rb
+++ b/lib/logstash-logger/device/tcp.rb
@@ -10,7 +10,7 @@ module LogStashLogger
 
         @ssl_certificate = opts[:ssl_certificate]
         @use_ssl = !!(@ssl_certificate || opts[:use_ssl] || opts[:ssl_enable])
-        @ssl_context = opts.fetch(:ssl_context, nil)
+        @ssl_context = opts.fetch(:ssl_context, OpenSSL::SSL::SSLContext.new)
       end
 
       def use_ssl?

--- a/spec/device/tcp_spec.rb
+++ b/spec/device/tcp_spec.rb
@@ -40,5 +40,16 @@ describe LogStashLogger::Device::TCP do
       expect(ssl_socket).to receive(:post_connection_check).with(HOST)
       ssl_tcp_device.connect
     end
+
+    context 'with a provided SSL context' do
+      let(:ssl_context) { 'test_ssl_context' }
+      let(:ssl_tcp_device) { LogStashLogger::Device.new(type: :tcp, port: port, ssl_enable: true, sync: true, ssl_context: ssl_context) }
+
+      it 'creates the socket using that context' do
+        expect(OpenSSL::SSL::SSLSocket).to receive(:new).with(tcp_socket, ssl_context)
+        ssl_tcp_device.connect
+      end
+    end
   end
+
 end

--- a/spec/device/tcp_spec.rb
+++ b/spec/device/tcp_spec.rb
@@ -13,6 +13,7 @@ describe LogStashLogger::Device::TCP do
     allow(OpenSSL::SSL::SSLSocket).to receive(:new) { ssl_socket }
     allow(ssl_socket).to receive(:connect)
     allow(ssl_socket).to receive(:post_connection_check)
+    allow(ssl_tcp_device).to receive(:warn)
   end
 
   context "when not using SSL" do
@@ -36,14 +37,19 @@ describe LogStashLogger::Device::TCP do
       expect(ssl_tcp_device.use_ssl?).to be_truthy
     end
 
-    it "checks ssl certificate validity" do
-      expect(ssl_socket).to receive(:post_connection_check).with(HOST)
+    it 'provides a warning about using a SSL context' do
+      expect(ssl_tcp_device).to receive(:warn).with("[DEPRECATION] 'LogStashLogger::Device::Socket' should be instantiated with a SSL context for hostname verification.")
       ssl_tcp_device.connect
     end
 
     context 'with a provided SSL context' do
       let(:ssl_context) { 'test_ssl_context' }
       let(:ssl_tcp_device) { LogStashLogger::Device.new(type: :tcp, port: port, ssl_enable: true, sync: true, ssl_context: ssl_context) }
+
+      it "checks ssl certificate validity" do
+        expect(ssl_socket).to receive(:post_connection_check).with(HOST)
+        ssl_tcp_device.connect
+      end
 
       it 'creates the socket using that context' do
         expect(OpenSSL::SSL::SSLSocket).to receive(:new).with(tcp_socket, ssl_context)

--- a/spec/device/tcp_spec.rb
+++ b/spec/device/tcp_spec.rb
@@ -12,6 +12,7 @@ describe LogStashLogger::Device::TCP do
 
     allow(OpenSSL::SSL::SSLSocket).to receive(:new) { ssl_socket }
     allow(ssl_socket).to receive(:connect)
+    allow(ssl_socket).to receive(:post_connection_check)
   end
 
   context "when not using SSL" do
@@ -33,6 +34,11 @@ describe LogStashLogger::Device::TCP do
 
     it "returns false for #use_ssl?" do
       expect(ssl_tcp_device.use_ssl?).to be_truthy
+    end
+
+    it "checks ssl certificate validity" do
+      expect(ssl_socket).to receive(:post_connection_check).with(HOST)
+      ssl_tcp_device.connect
     end
   end
 end


### PR DESCRIPTION
Verifying SSL host against the certificate provided.

Certificate host expiry, etc is checked only as a manual step after connection. It is not an automatic action in OpenSSL. This enables that check.

This means that:
- self signed certs will not work without specifying the SSL context
- hosts with a cert for "my-evil-domain.com" will fail to connect if their host name is "my-real-company.com"

Without these checks, all SSL connections are vulnerable to man in the middle attacks.
