### PR TITLE
do not raise error on failure to send log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ tmp
 .idea/
 log/
 .ruby-version
+logstash-logger.sublime-project
+logstash-logger.sublime-workspace

--- a/lib/logstash-logger/device/connectable.rb
+++ b/lib/logstash-logger/device/connectable.rb
@@ -75,7 +75,8 @@ module LogStashLogger
       rescue => e
         warn "#{self.class} - #{e.class} - #{e.message}"
         @io = nil
-        raise
+        # DO NOT RAISE AN EXCEPTION IF YOU CANNOT LOG
+        #raise
       end
     end
   end


### PR DESCRIPTION
It is a bummer if we cannot log, but we do not want to actually raise an error at this point.