### PR TITLE
Provide `max_message_size` option

### DIFF
--- a/lib/logstash-logger/configuration.rb
+++ b/lib/logstash-logger/configuration.rb
@@ -10,6 +10,7 @@ module LogStashLogger
 
   class Configuration
     attr_accessor :customize_event_block
+    attr_accessor :max_message_size
 
     def initialize(*args)
       @customize_event_block = nil

--- a/lib/logstash-logger/formatter/base.rb
+++ b/lib/logstash-logger/formatter/base.rb
@@ -44,6 +44,10 @@ module LogStashLogger
         if event.timestamp.is_a?(Time)
           event.timestamp = event.timestamp.iso8601(3)
         end
+
+        if LogStashLogger.configuration.max_message_size
+          event['message'.freeze] = event['message'.freeze].byteslice(0, LogStashLogger.configuration.max_message_size)
+        end
         
         event
       end


### PR DESCRIPTION
This mitigates the issue with UDP packet size limits. (https://github.com/dwbutler/logstash-logger/issues/78)