### PR TITLE
Allow log messages to be dropped

### DIFF
--- a/lib/logstash-logger/device/redis.rb
+++ b/lib/logstash-logger/device/redis.rb
@@ -10,6 +10,7 @@ module LogStashLogger
       def initialize(opts)
         super
         @list = opts.delete(:list) || DEFAULT_LIST
+        @buffer_group = @list
 
         normalize_path(opts)
 
@@ -36,11 +37,6 @@ module LogStashLogger
         raise
       end
 
-      def write(message)
-        buffer_receive message, @list
-        buffer_flush(force: true) if @sync
-      end
-
       def write_batch(messages, list = nil)
         with_connection do
           @io.rpush(list, messages)
@@ -56,15 +52,6 @@ module LogStashLogger
         @io = nil
       end
 
-      def flush(*args)
-        if args.empty?
-          buffer_flush
-        else
-          messages, list = *args
-          write_batch(messages, list)
-        end
-      end
-      
       private
 
       def normalize_path(opts)


### PR DESCRIPTION
LogStashLogger currently uses `Stud::Buffer` to implement buffering for connectable devices (such as TCP, Redis, etc.) When the remote service goes down, an exception is raised when a buffer flush is attempted. By default `Stud::Buffer` will retry sending the messages forever. Since a flush is triggered when a message is received, or on a regular timer, this will cause logging calls to block. See https://github.com/jordansissel/ruby-stud/issues/28

`Stud::Buffer` allows callbacks to be fired when it encounters a flush error. This ties into that mechanism to abort the flush and re-enqueue the failed messages. This behavior is now enabled by default. To instead drop messages when there is a flush error, pass the new `drop_messages_on_flush_error` option to the logger.

Most applications will want to buffer messages and only drop them when the buffer fills up. This behavior has been implemented by tying into `Stud::Buffer`'s callback for the buffer full event. By default, when the buffer is full, `Stud::Buffer` will block when any new message comes in, until there is room in the buffer. If you want to discard messages in the buffer when this happens, pass the new `drop_messages_on_full_buffer` option to the logger.

Fixes https://github.com/dwbutler/logstash-logger/issues/68