### PR TITLE
Unify error logging

### DIFF
--- a/lib/logstash-logger/configuration.rb
+++ b/lib/logstash-logger/configuration.rb
@@ -15,7 +15,7 @@ module LogStashLogger
 
     def initialize(*args)
       @customize_event_block = nil
-      @default_error_logger = Logger.new(STDERR)
+      @default_error_logger = Logger.new($stderr)
 
       yield self if block_given?
       self

--- a/lib/logstash-logger/configuration.rb
+++ b/lib/logstash-logger/configuration.rb
@@ -11,9 +11,11 @@ module LogStashLogger
   class Configuration
     attr_accessor :customize_event_block
     attr_accessor :max_message_size
+    attr_accessor :default_error_logger
 
     def initialize(*args)
       @customize_event_block = nil
+      @default_error_logger = Logger.new(STDERR)
 
       yield self if block_given?
       self

--- a/lib/logstash-logger/device/base.rb
+++ b/lib/logstash-logger/device/base.rb
@@ -3,9 +3,11 @@ module LogStashLogger
     class Base
       attr_reader :io
       attr_accessor :sync
+      attr_accessor :error_logger
 
       def initialize(opts={})
         @sync = opts[:sync]
+        @error_logger = opts.fetch(:error_logger, LogStashLogger.configuration.default_error_logger)
       end
 
       def to_io
@@ -23,9 +25,19 @@ module LogStashLogger
       def close
         @io && @io.close
       rescue => e
-        warn "#{self.class} - #{e.class} - #{e.message}"
+        log_error(e)
       ensure
         @io = nil
+      end
+
+      private
+
+      def log_error(e)
+        error_logger.error "[#{self.class}] #{e.class} - #{e.message}"
+      end
+
+      def log_warning(message)
+        error_logger.warn("[#{self.class}] #{message}")
       end
     end
   end

--- a/lib/logstash-logger/device/connectable.rb
+++ b/lib/logstash-logger/device/connectable.rb
@@ -95,7 +95,7 @@ module LogStashLogger
         connect unless connected?
         yield
       rescue => e
-        warn "#{self.class} - #{e.class} - #{e.message}"
+        log_error(e)
         @io = nil
         raise
       end

--- a/lib/logstash-logger/device/kafka.rb
+++ b/lib/logstash-logger/device/kafka.rb
@@ -36,12 +36,14 @@ module LogStashLogger
         connect unless @io
         yield
       rescue ::Poseidon::Errors::ChecksumError, Poseidon::Errors::UnableToFetchMetadata => e
-        warn "#{self.class} - #{e.class} -> reconnect/retry"
+        log_error(e)
+        log_warning("reconnect/retry")
         sleep backoff if backoff
         reconnect
         retry
       rescue => e
-        warn "#{self.class} - #{e.class} - #{e.message} -> giving up"
+        log_error(e)
+        log_warning("giving up")
         @io = nil
       end
 
@@ -55,7 +57,7 @@ module LogStashLogger
         buffer_flush(final: true)
         @io && @io.close
       rescue => e
-        warn "#{self.class} - #{e.class} - #{e.message}"
+        log_error(e)
       ensure
         @io = nil
       end

--- a/lib/logstash-logger/device/redis.rb
+++ b/lib/logstash-logger/device/redis.rb
@@ -32,7 +32,7 @@ module LogStashLogger
         reconnect
         retry
       rescue => e
-        warn "#{self.class} - #{e.class} - #{e.message}"
+        log_error(e)
         @io = nil
         raise
       end
@@ -47,7 +47,7 @@ module LogStashLogger
         buffer_flush(final: true)
         @io && @io.quit
       rescue => e
-        warn "#{self.class} - #{e.class} - #{e.message}"
+        log_error(e)
       ensure
         @io = nil
       end


### PR DESCRIPTION
Internal refactoring to make all error logging go through an error logger. The default error logger logs to STDERR, but a custom error logger can be provided by passing a new `error_logger` option or by changing `LogStashLogger.configuration.default_error_logger`.