### PR TITLE
Safely close connection when reconnecting

### DIFF
--- a/lib/logstash-logger/device/balancer.rb
+++ b/lib/logstash-logger/device/balancer.rb
@@ -6,7 +6,7 @@ module LogStashLogger
       def initialize(opts)
         @io = self
         @devices = create_devices(opts[:outputs])
-        self.class.delegate_to_all(:close, :flush)
+        self.class.delegate_to_all(:close, :close!, :flush)
         self.class.delegate_to_one(:write)
       end
 

--- a/lib/logstash-logger/device/base.rb
+++ b/lib/logstash-logger/device/base.rb
@@ -35,14 +35,24 @@ module LogStashLogger
         end
       end
 
+      def write_batch(messages, group = nil)
+        messages.each do |message|
+          @io.write(message)
+        end
+      end
+
       def flush
         @io && @io.flush
       end
 
-      def close
-        @io && @io.close
+      def close(opts = {})
+        close!
       rescue => e
         log_error(e)
+      end
+
+      def close!
+        @io && @io.close
       ensure
         @io = nil
       end

--- a/lib/logstash-logger/device/connectable.rb
+++ b/lib/logstash-logger/device/connectable.rb
@@ -68,8 +68,11 @@ module LogStashLogger
         end
       end
 
-      def close
-        buffer_flush(final: true)
+      def close(opts = {})
+        if opts.fetch(:flush, true)
+          buffer_flush(final: true)
+        end
+
         super
       end
 
@@ -101,8 +104,7 @@ module LogStashLogger
       end
 
       def reconnect
-        @io.close if @io
-        @io = nil
+        close(flush: false)
         connect
       end
 
@@ -112,8 +114,7 @@ module LogStashLogger
         yield
       rescue => e
         log_error(e)
-        @io.close if @io
-        @io = nil
+        close(flush: false)
         raise
       end
 

--- a/lib/logstash-logger/device/multi_delegator.rb
+++ b/lib/logstash-logger/device/multi_delegator.rb
@@ -11,7 +11,7 @@ module LogStashLogger
       def initialize(opts)
         @io = self
         @devices = create_devices(opts[:outputs])
-        self.class.delegate(:write, :close, :flush)
+        self.class.delegate(:write, :close, :close!, :flush)
       end
 
       private

--- a/lib/logstash-logger/device/stderr.rb
+++ b/lib/logstash-logger/device/stderr.rb
@@ -5,7 +5,7 @@ module LogStashLogger
         super({io: $stderr}.merge(opts))
       end
 
-      def close
+      def close!
         # no-op
       end
     end

--- a/lib/logstash-logger/device/stdout.rb
+++ b/lib/logstash-logger/device/stdout.rb
@@ -5,7 +5,7 @@ module LogStashLogger
         super({io: $stdout}.merge(opts))
       end
 
-      def close
+      def close!
         # no-op
         # Calling $stdout.close would be a bad idea
       end


### PR DESCRIPTION
When a reconnecting a connectable device, the connection should first be (safely) closed. This is accomplished by making two changes. First, all devices now have two methods: `close!` (unsafe close without error handling) and `close` (close with error handling). Second, connectable devices can take a new option, `flush: false` to close the connection without flushing messages. Together, this makes it safe to close the connection when reconnecting without losing any messages in case closing fails due to a connection issue.

Fixes https://github.com/dwbutler/logstash-logger/pull/66