### PR TITLE
Support for logger silencing

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,18 @@ change the error logger by setting `LogStashLogger.configuration.default_error_l
 your own logger object in the `:error_logger` configuration key when
 instantiating a LogStashLogger.
 
+## Logger Silencing
+
+LogStashLogger provides support for Rails-style logger silencing. The
+implementation was extracted from Rails, but has no dependencies, so it can be
+used outside of a Rails app. The interface is the same as in Rails:
+
+```ruby
+logger.silence(temporary_level) do
+  ...
+end
+```
+
 ## Rails Integration
 
 Verified to work with both Rails 3, 4, and 5.

--- a/lib/logstash-logger/logger.rb
+++ b/lib/logstash-logger/logger.rb
@@ -1,5 +1,6 @@
 require 'logger'
 require 'logstash-logger/tagged_logging'
+require 'logstash-logger/silenced_logging'
 
 module LogStashLogger
   autoload :MultiLogger, 'logstash-logger/multi_logger'
@@ -68,6 +69,7 @@ module LogStashLogger
       logger.instance_variable_set(:@device, device)
       logger.extend(self)
       logger.extend(TaggedLogging)
+      logger.extend(SilencedLogging)
     end
   end
 
@@ -87,5 +89,6 @@ module LogStashLogger
 
     logger.extend(self)
     logger.extend(TaggedLogging)
+    logger.extend(SilencedLogging)
   end
 end

--- a/lib/logstash-logger/multi_logger.rb
+++ b/lib/logstash-logger/multi_logger.rb
@@ -46,7 +46,7 @@ module LogStashLogger
         silence_loggers(temporary_level, silenceable_loggers, &block)
       end
     end
-    private :silenceable_loggers
+    private :silence_loggers
 
     def tagged(*tags, &block)
       taggable_loggers = @loggers.select do |logger|

--- a/lib/logstash-logger/silenced_logging.rb
+++ b/lib/logstash-logger/silenced_logging.rb
@@ -19,20 +19,20 @@ require 'thread'
 module LogStashLogger
   module SilencedLogging
     def self.extended(logger)
-      logger.class_eval do
+      class << logger
         attr_accessor :silencer
         alias_method :level_without_threadsafety, :level
         alias_method :level, :level_with_threadsafety
         alias_method :add_without_threadsafety, :add
         alias_method :add, :add_with_threadsafety
-      end
 
-      Logger::Severity.constants.each do |severity|
-        logger.class_eval <<-EOT, __FILE__, __LINE__ + 1
-          def #{severity.downcase}?                # def debug?
-            Logger::#{severity} >= level           #   DEBUG >= level
-          end                                      # end
-        EOT
+        Logger::Severity.constants.each do |severity|
+          instance_eval <<-EOT, __FILE__, __LINE__ + 1
+            def #{severity.downcase}?                # def debug?
+              Logger::#{severity} >= level           #   DEBUG >= level
+            end                                      # end
+          EOT
+        end
       end
 
       logger.instance_eval do

--- a/lib/logstash-logger/silenced_logging.rb
+++ b/lib/logstash-logger/silenced_logging.rb
@@ -1,0 +1,83 @@
+# Adapted from:
+# https://github.com/rails/activerecord-session_store/blob/master/lib/active_record/session_store/extension/logger_silencer.rb
+# https://github.com/rails/rails/pull/16885
+
+require 'thread'
+
+# Add support for Rails-style logger silencing. Thread-safe and no dependencies.
+#
+# Setup:
+#   logger = Logger.new(STDOUT)
+#   logger.extend(LogStashLogger::SilencedLogging)
+#
+# Usage:
+#
+#   logger.silence do
+#     ...
+#   end
+#
+module LogStashLogger
+  module SilencedLogging
+    def self.extended(logger)
+      logger.class_eval do
+        attr_accessor :silencer
+        alias_method :level_without_threadsafety, :level
+        alias_method :level, :level_with_threadsafety
+        alias_method :add_without_threadsafety, :add
+        alias_method :add, :add_with_threadsafety
+      end
+
+      Logger::Severity.constants.each do |severity|
+        logger.class_eval <<-EOT, __FILE__, __LINE__ + 1
+          def #{severity.downcase}?                # def debug?
+            Logger::#{severity} >= level           #   DEBUG >= level
+          end                                      # end
+        EOT
+      end
+
+      logger.instance_eval do
+        self.silencer = true
+      end
+    end
+
+    def thread_level
+      Thread.current[thread_hash_level_key]
+    end
+
+    def thread_level=(level)
+      Thread.current[thread_hash_level_key] = level
+    end
+
+    def level_with_threadsafety
+      thread_level || level_without_threadsafety
+    end
+
+    def add_with_threadsafety(severity, message = nil, progname = nil, &block)
+      if (defined?(@logdev) && @logdev.nil?) || (severity || UNKNOWN) < level
+        true
+      else
+        add_without_threadsafety(severity, message, progname, &block)
+      end
+    end
+
+    # Silences the logger for the duration of the block.
+    def silence(temporary_level = Logger::ERROR)
+      if silencer
+        begin
+          self.thread_level = temporary_level
+          yield self
+        ensure
+          self.thread_level = nil
+        end
+      else
+        yield self
+      end
+    end
+
+    private
+
+    def thread_hash_level_key
+      @thread_hash_level_key ||= :"ThreadSafeLogger##{object_id}@level"
+    end
+  end
+end

--- a/spec/silenced_logging_spec.rb
+++ b/spec/silenced_logging_spec.rb
@@ -1,0 +1,31 @@
+require 'logstash-logger'
+
+describe LogStashLogger do
+  include_context 'logger'
+
+  describe "silenced logging" do
+
+    it "yields the logger" do
+      logger.silence do |yielded|
+        expect(yielded).to eq(logger)
+      end
+    end
+
+    it "silences any message below ERROR level by default" do
+      logger.silence do
+        expect(logger.device).to receive(:write).once
+        logger.info("info")
+        logger.warn("warning")
+        logger.error("error")
+      end
+    end
+
+    it "takes a custom log level to silence to" do
+      logger.silence(::Logger::WARN) do
+        expect(logger.device).to receive(:write).once
+        logger.info("info")
+        logger.warn("warning")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds support for the same `Logger#silence` interface provided by Rails. This was extracted from Rails, but has no dependencies. So the functionality can be used without Rails. The interface is the same as the one provided by Rails.

In the process, I fixed support for tagged logging in `MultiLogger`.

Fixes https://github.com/dwbutler/logstash-logger/issues/86