### PR TITLE
Only require logstash-logger/railtie if Rails::Railtie is defined

### DIFF
--- a/lib/logstash-logger.rb
+++ b/lib/logstash-logger.rb
@@ -8,4 +8,4 @@ require 'logstash-logger/logger'
 require 'logstash-logger/formatter'
 require 'logstash-logger/configuration'
 
-require 'logstash-logger/railtie' if defined? Rails
+require 'logstash-logger/railtie' if defined?(Rails) && defined?(Rails::Railtie)


### PR DESCRIPTION
 - When using ActiveSupport inflector by itself (without the rest
 of Rails), the Rails module is defined, but Rails::Railtie is not.
 This causes an error during bundler bootstrapping