### PR TITLE
Flush log messages when exiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ You can configure its behavior by passing the following options to LogStashLogge
 * :drop_messages_on_flush_error - Drop messages when there is a flush error. Defaults to false.
 * :drop_messages_on_full_buffer - Drop messages when the buffer is full. Defaults to true.
 * :sync - Flush buffer every time a message is received (blocking). Defaults to false.
+* :buffer_flush_at_exit - Flush messages when exiting the program. Defaults to true.
 
 You can turn buffering off by setting `sync = true`.
 

--- a/lib/logstash-logger/buffer.rb
+++ b/lib/logstash-logger/buffer.rb
@@ -95,8 +95,13 @@ module LogStashLogger
         :has_on_flush_error => self.class.method_defined?(:on_flush_error),
         :has_on_full_buffer_receive => self.class.method_defined?(:on_full_buffer_receive),
         :drop_messages_on_flush_error => options.fetch(:drop_messages_on_flush_error, false),
-        :drop_messages_on_full_buffer => options.fetch(:drop_messages_on_full_buffer, false)
+        :drop_messages_on_full_buffer => options.fetch(:drop_messages_on_full_buffer, false),
+        :flush_at_exit => options.fetch(:flush_at_exit, false)
       }
+
+      if @buffer_config[:flush_at_exit]
+        at_exit { buffer_flush(final: true) }
+      end
 
       reset_buffer
     end

--- a/lib/logstash-logger/device/connectable.rb
+++ b/lib/logstash-logger/device/connectable.rb
@@ -33,12 +33,20 @@ module LogStashLogger
             true
           end
 
+        @buffer_flush_at_exit =
+          if opts.key?(:buffer_flush_at_exit)
+            opts.delete(:buffer_flush_at_exit)
+          else
+            true
+          end
+
         buffer_initialize(
           max_items: @buffer_max_items,
           max_interval: @buffer_max_interval,
           autoflush: @sync,
           drop_messages_on_flush_error: @drop_messages_on_flush_error,
-          drop_messages_on_full_buffer: @drop_messages_on_full_buffer
+          drop_messages_on_full_buffer: @drop_messages_on_full_buffer,
+          flush_at_exit: @buffer_flush_at_exit
         )
       end
 


### PR DESCRIPTION
The current implementation of message buffering puts messages into a queue, and flushes them every five seconds. If the program exits, any messages in the buffer will be lost.

This fixes the issue by automatically flushing the buffer when the program exits. This is done by registering an `at_exit` block which does a final flush, which will wait for all messages to be flushed. If an exception occurs, it will be logged and ignored.

This option is configurable with the new option `buffer_flush_at_exit`, which now defaults to `true`.

Fixes #91 