### PR TITLE
Fix `Logger#silence`

### DIFF
--- a/lib/logstash-logger/logger.rb
+++ b/lib/logstash-logger/logger.rb
@@ -67,9 +67,7 @@ module LogStashLogger
     device = Device.new(opts)
     ::Logger.new(device).tap do |logger|
       logger.instance_variable_set(:@device, device)
-      logger.extend(self)
-      logger.extend(TaggedLogging)
-      logger.extend(SilencedLogging)
+      extend_logger(logger)
     end
   end
 
@@ -87,8 +85,12 @@ module LogStashLogger
       Syslog::Logger.new(opts[:program_name])
     end
 
+    extend_logger(logger)
+  end
+
+  def self.extend_logger(logger)
     logger.extend(self)
-    logger.extend(TaggedLogging)
-    logger.extend(SilencedLogging)
+    logger.extend(TaggedLogging) unless logger.respond_to?(:tagged)
+    logger.extend(SilencedLogging) unless logger.respond_to?(:silence)
   end
 end


### PR DESCRIPTION
LogStashLogger's implementation of `Logger#silence` is derived from `ActiveRecord::SessionStore::Extension::LoggerSilencer`. If `ActiveRecord::SessionStore` is in use, this module gets included into `Logger`. This causes `LogStashLogger::SilencedLogging`'s monkey patching to interfere with the same monkey patching done by `ActiveRecord::SessionStore`.

The solution is to only use LogStashLogger's silenced logging extension if silenced logging is not available. If Logger already responds to `#silence`, it is assumed that a silencing mechanism has already been monkey patched in from elsewhere. For completeness, the same strategy is also used for tagged logging.

Fixes https://github.com/dwbutler/logstash-logger/issues/94