### PR TITLE
Fix Logger#silence monkey patching

### DIFF
--- a/lib/logstash-logger/logger.rb
+++ b/lib/logstash-logger/logger.rb
@@ -90,7 +90,7 @@ module LogStashLogger
 
   def self.extend_logger(logger)
     logger.extend(self)
-    logger.extend(TaggedLogging) unless logger.respond_to?(:tagged)
-    logger.extend(SilencedLogging) unless logger.respond_to?(:silence)
+    logger.extend(TaggedLogging)
+    logger.extend(SilencedLogging)
   end
 end

--- a/lib/logstash-logger/logger.rb
+++ b/lib/logstash-logger/logger.rb
@@ -67,9 +67,7 @@ module LogStashLogger
     device = Device.new(opts)
     ::Logger.new(device).tap do |logger|
       logger.instance_variable_set(:@device, device)
-      logger.extend(self)
-      logger.extend(TaggedLogging)
-      logger.extend(SilencedLogging)
+      extend_logger(logger)
     end
   end
 
@@ -87,8 +85,12 @@ module LogStashLogger
       Syslog::Logger.new(opts[:program_name])
     end
 
+    extend_logger(logger)
+  end
+
+  def self.extend_logger(logger)
     logger.extend(self)
-    logger.extend(TaggedLogging)
-    logger.extend(SilencedLogging)
+    logger.extend(TaggedLogging) unless logger.respond_to?(:tagged)
+    logger.extend(SilencedLogging) unless logger.respond_to?(:silence)
   end
 end

--- a/lib/logstash-logger/silenced_logging.rb
+++ b/lib/logstash-logger/silenced_logging.rb
@@ -21,10 +21,10 @@ module LogStashLogger
     def self.extended(logger)
       class << logger
         attr_accessor :silencer
-        alias_method :level_without_threadsafety, :level
-        alias_method :level, :level_with_threadsafety
-        alias_method :add_without_threadsafety, :add
-        alias_method :add, :add_with_threadsafety
+        alias_method :level_without_thread_safety, :level
+        alias_method :level, :level_with_thread_safety
+        alias_method :add_without_thread_safety, :add
+        alias_method :add, :add_with_thread_safety
 
         Logger::Severity.constants.each do |severity|
           instance_eval <<-EOT, __FILE__, __LINE__ + 1
@@ -48,15 +48,15 @@ module LogStashLogger
       Thread.current[thread_hash_level_key] = level
     end
 
-    def level_with_threadsafety
-      thread_level || level_without_threadsafety
+    def level_with_thread_safety
+      thread_level || level_without_thread_safety
     end
 
-    def add_with_threadsafety(severity, message = nil, progname = nil, &block)
+    def add_with_thread_safety(severity, message = nil, progname = nil, &block)
       if (defined?(@logdev) && @logdev.nil?) || (severity || UNKNOWN) < level
         true
       else
-        add_without_threadsafety(severity, message, progname, &block)
+        add_without_thread_safety(severity, message, progname, &block)
       end
     end
 


### PR DESCRIPTION
LogStashLogger's implementation of `Logger#silence` is derived from `ActiveRecord::SessionStore::Extension::LoggerSilencer`. If `ActiveRecord::SessionStore` is in use, this module gets included into `Logger`. This causes `LogStashLogger::SilencedLogging`'s monkey patching to interfere with the same monkey patching done by `ActiveRecord::SessionStore`.

The solution is to change the names of the monkey patched methods so they don't interfere with the ones defined in `ActiveRecord::SessionStore`.

Fixes #94