### PR TITLE
Memoize buffer mutexes

### DIFF
--- a/lib/logstash-logger/buffer.rb
+++ b/lib/logstash-logger/buffer.rb
@@ -113,14 +113,14 @@ module LogStashLogger
         :pending_count => 0,
 
         # guard access to pending_items & pending_count
-        :pending_mutex => Mutex.new,
+        :pending_mutex => pending_mutex,
 
         # items which are currently being flushed
         :outgoing_items => {},
         :outgoing_count => 0,
 
         # ensure only 1 flush is operating at once
-        :flush_mutex => Mutex.new,
+        :flush_mutex => flush_mutex,
 
         # data for timed flushes
         :last_flush => Time.now,
@@ -284,6 +284,15 @@ module LogStashLogger
     end
 
     private
+
+    def pending_mutex
+      @pending_mutex ||= Mutex.new
+    end
+
+    def flush_mutex
+      @flush_mutex ||= Mutex.new
+    end
+
     def buffer_clear_pending
       @buffer_state[:pending_items] = Hash.new { |h, k| h[k] = [] }
       @buffer_state[:pending_count] = 0

--- a/lib/logstash-logger/buffer.rb
+++ b/lib/logstash-logger/buffer.rb
@@ -120,20 +120,13 @@ module LogStashLogger
         :outgoing_count => 0,
 
         # ensure only 1 flush is operating at once
-        :flush_mutex => flush_mutex,
+        :flush_mutex =>    flush_mutex,
 
         # data for timed flushes
-        :last_flush => Time.now,
-        :timer => Thread.new do
-          loop do
-            sleep(@buffer_config[:max_interval])
-            begin
-              buffer_flush(:force => true)
-            rescue
-            end
-          end
-        end
+        :last_flush =>     Time.now,
+        :timer =>          flush_timer_thread
       }
+
 
       # events we've accumulated
       buffer_clear_pending
@@ -291,6 +284,19 @@ module LogStashLogger
 
     def flush_mutex
       @flush_mutex ||= Mutex.new
+    end
+
+    def flush_timer_thread
+      @flush_timer_thread ||=
+        Thread.new do
+          loop do
+            sleep(@buffer_config[:max_interval])
+            begin
+              buffer_flush(:force => true)
+            rescue
+            end
+          end
+        end
     end
 
     def buffer_clear_pending


### PR DESCRIPTION
When the buffer state is reset after dropping messages, the mutexes are also reinitialized with new instances. This causes an issue with `buffer_flush` when it tries to unlock the new mutex that it never locked, raising `Attempt to unlock a mutex which is not locked (ThreadError)`.

This fixes the issue by memoizing the buffer mutexes and reusing them even when the buffer state is reset.

Fixes https://github.com/dwbutler/logstash-logger/issues/97