### PR TITLE
Fix internal buffer logger

### DIFF
--- a/lib/logstash-logger/buffer.rb
+++ b/lib/logstash-logger/buffer.rb
@@ -225,14 +225,17 @@ module LogStashLogger
           buffer_clear_pending
         end
 
-        @buffer_config[:logger].debug("Flushing output",
-          :outgoing_count => @buffer_state[:outgoing_count],
-          :time_since_last_flush => time_since_last_flush,
-          :outgoing_events => @buffer_state[:outgoing_items],
-          :batch_timeout => @buffer_config[:max_interval],
-          :force => force,
-          :final => final
-        ) if @buffer_config[:logger]
+        @buffer_config[:logger].debug do
+          debug_output = {
+            :outgoing_count => @buffer_state[:outgoing_count],
+            :time_since_last_flush => time_since_last_flush,
+            :outgoing_events => @buffer_state[:outgoing_items],
+            :batch_timeout => @buffer_config[:max_interval],
+            :force => force,
+            :final => final
+          }
+          "Flushing output: #{debug_output}"
+        end if @buffer_config[:logger]
 
         @buffer_state[:outgoing_items].each do |group, events|
           begin
@@ -250,11 +253,14 @@ module LogStashLogger
 
           rescue => e
 
-            @buffer_config[:logger].warn("Failed to flush outgoing items",
-              :outgoing_count => @buffer_state[:outgoing_count],
-              :exception => e.class.name,
-              :backtrace => e.backtrace
-            ) if @buffer_config[:logger]
+            @buffer_config[:logger].warn do
+              warn_output = {
+                :outgoing_count => @buffer_state[:outgoing_count],
+                :exception => e.class.name,
+                :backtrace => e.backtrace
+              }
+              "Failed to flush outgoing items: #{warn_output}"
+            end if @buffer_config[:logger]
 
             if @buffer_config[:has_on_flush_error]
               on_flush_error e

--- a/lib/logstash-logger/device/connectable.rb
+++ b/lib/logstash-logger/device/connectable.rb
@@ -5,6 +5,8 @@ module LogStashLogger
     class Connectable < Base
       include LogStashLogger::Buffer
 
+      attr_accessor :buffer_logger
+
       def initialize(opts = {})
         super
 
@@ -40,9 +42,12 @@ module LogStashLogger
             true
           end
 
+        @buffer_logger = opts[:buffer_logger]
+
         buffer_initialize(
           max_items: @buffer_max_items,
           max_interval: @buffer_max_interval,
+          logger: buffer_logger,
           autoflush: @sync,
           drop_messages_on_flush_error: @drop_messages_on_flush_error,
           drop_messages_on_full_buffer: @drop_messages_on_full_buffer,


### PR DESCRIPTION
The buffer implementation vendored from `Stud:Buffer` has an internal logger. However, it's called with non-standard arguments not supported by Ruby's standard Logger class. This fixes the issue by logging in the standard way. A new `buffer_logger` configuration variable is also exposed to allow the buffer logger to be set.

Fixes https://github.com/dwbutler/logstash-logger/issues/101
