### PR TITLE
New kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ file_logger = LogStashLogger.new(type: :file, path: 'log/development.log', sync:
 unix_logger = LogStashLogger.new(type: :unix, path: '/tmp/sock')
 syslog_logger = LogStashLogger.new(type: :syslog)
 redis_logger = LogStashLogger.new(type: :redis)
-kafka_logger = LogStashLogger.new(type: :kafka)
+** NOTE: The current kafka class will be deprecated in a future version.
+  For now, migrate to using kafka_new**
+kafka_logger = LogStashLogger.new(type: :kafka_new)
 stdout_logger = LogStashLogger.new(type: :stdout)
 stderr_logger = LogStashLogger.new(type: :stderr)
 io_logger = LogStashLogger.new(type: :io, io: io)
@@ -454,26 +456,37 @@ config.logstash.port = 6379
 
 #### Kafka
 
-Add the poseidon gem to your Gemfile:
+Add the ruby-kafka gem to your Gemfile:
 
-    gem 'poseidon'
+    gem 'ruby-kafka'
 
 ```ruby
+## NOTE: A future version of this gem will remove the current
+# implementation of the kafka client. This will be a breaking change. Use
+# kafka_new to ensure forward compatibility
 # Required
-config.logstash.type = :kafka
 
-# Optional, will default to the 'logstash' topic
-config.logstash.path = 'logstash'
+config.logstash.type = :kafka_new
 
-# Optional, will default to the 'logstash-logger' producer
-config.logstash.producer = 'logstash-logger'
+# Required
+config.logstash.topic = 'logstash-topic'
 
-# Optional, will default to localhost:9092 host/port
-config.logstash.hosts = ['localhost:9092']
+# Required, can be in one of two formats:
+# String format (splits on single space):
+config.logstash.brokers = 'localhost:9092 some-other-host.net:9300'
+# Array format
+config.logstash.brokers = %w(localhost:9092 some-other-host.net:9300)
 
-# Optional, will default to 1s backoff
-config.logstash.backoff = 1
+# Optional, defaults to 'ruby-kafka'
+config.logstash.client_id = 'logstash-client-alpha'
 
+# Optional, transmit over TLS
+# NOTE: either 0 or all 3 ssl_parameters must be provided for a
+# successful connection. An exception will be raised if 1 or 2 params
+# are povided
+config.logstash.ssl_ca_cert: ENV['CLOUDKAFKA_CA']
+config.logstash.ssl_client_cert: ENV['CLOUDKAFKA_CERT']
+config.logstash.ssl_client_cert_key: ENV['CLOUDKAFKA_PRIVATE_KEY']
 ```
 
 #### File

--- a/lib/logstash-logger/device.rb
+++ b/lib/logstash-logger/device.rb
@@ -51,6 +51,7 @@ module LogStashLogger
         when :file then File
         when :redis then Redis
         when :kafka then Kafka
+        when :kafka_new then KafkaNew
         when :io then IO
         when :stdout then Stdout
         when :stderr then Stderr

--- a/lib/logstash-logger/device.rb
+++ b/lib/logstash-logger/device.rb
@@ -12,6 +12,7 @@ module LogStashLogger
     autoload :Unix, 'logstash-logger/device/unix'
     autoload :Redis, 'logstash-logger/device/redis'
     autoload :Kafka, 'logstash-logger/device/kafka'
+    autoload :KafkaNew, 'logstash-logger/device/kafka_new'
     autoload :File, 'logstash-logger/device/file'
     autoload :IO, 'logstash-logger/device/io'
     autoload :Stdout, 'logstash-logger/device/stdout'

--- a/lib/logstash-logger/device/kafka.rb
+++ b/lib/logstash-logger/device/kafka.rb
@@ -13,6 +13,9 @@ module LogStashLogger
       attr_accessor :hosts, :topic, :producer, :backoff
 
       def initialize(opts)
+
+        # TODO: improve this message and update README
+        warn "[DEPRECATED] Poseidon is deprecated, update client"
         super
         host = opts[:host] || DEFAULT_HOST
         port = opts[:port] || DEFAULT_PORT

--- a/lib/logstash-logger/device/kafka.rb
+++ b/lib/logstash-logger/device/kafka.rb
@@ -12,10 +12,15 @@ module LogStashLogger
 
       attr_accessor :hosts, :topic, :producer, :backoff
 
-      def initialize(opts)
+      @@deprecation_message = <<-MSG
+          [DEPRECATION WARNING]
+          Poseidon client will be deprecated and requires different configuration
+          parameters (but they are similar). Update your Kafka configuration to
+          use :kafka_new to ensure forward compatibility
+        MSG
 
-        # TODO: improve this message and update README
-        warn "[DEPRECATED] Poseidon is deprecated, update client"
+      def initialize(opts)
+        warn @@deprecation_message
         super
         host = opts[:host] || DEFAULT_HOST
         port = opts[:port] || DEFAULT_PORT

--- a/lib/logstash-logger/device/kafka_new.rb
+++ b/lib/logstash-logger/device/kafka_new.rb
@@ -1,0 +1,83 @@
+module LogStashLogger
+  module Device
+    class KafkaNew < Connectable
+      class TLSConfiguration
+        attr_reader :ssl_ca_cert, :ssl_client_cert, :ssl_client_cert_key
+
+        def initialize(opts = {})
+          @ssl_ca_cert = opts[:ssl_ca_cert]
+          @ssl_client_cert = opts[:ssl_client_cert]
+          @ssl_client_cert_key = opts[:ssl_client_cert_key]
+        end
+
+        def cert_bundle
+          @cert_bundle ||= all_cert_params? ? cert_params_as_hash : {}
+        end
+
+        def valid?
+          all_cert_params? || no_cert_params?
+        end
+
+        def invalid?
+          !valid?
+        end
+        private
+
+        def cert_params_as_hash
+          { ssl_ca_cert: @ssl_ca_cert,
+            ssl_client_cert: @ssl_client_cert,
+            ssl_client_cert_key: @ssl_client_cert_key,
+          }
+        end
+
+        def all_cert_params?
+          cert_params_as_hash.values.compact.length == valid_cert_params_length
+        end
+
+        def no_cert_params?
+          cert_params_as_hash.values.compact.empty?
+        end
+
+        def valid_cert_params_length
+          cert_params_as_hash.keys.length
+        end
+      end
+
+      attr_reader :topic, :brokers, :cert_bundle, :kafka_tls_configurator
+
+
+      # TODO: support client_id
+      def initialize(opts = {}, kafka_tls_configurator = TLSConfiguration)
+        require 'ruby-kafka'
+
+        @kafka_tls_configurator = kafka_tls_configurator
+        @brokers = make_brokers_array(opts[:brokers])
+        make_cert_bundle(opts)
+      end
+
+      def connect
+        connect_opts = @cert_bundle.merge({ seed_brokers: @brokers })
+        ::Kafka.new(connect_opts)
+      end
+
+      private
+
+      def make_brokers_array(opt)
+        case opt
+        when Array
+          opt
+        when String
+          opt.split("\s")
+        end
+      end
+
+      def make_cert_bundle(opts)
+        tls_conf = kafka_tls_configurator.new(opts)
+        if tls_conf.invalid?
+          fail ArgumentError, "all ssl parameters (ssl_ca_cert, ssl_client_cert and ssl_client_cert_key) are required or do use any of them to not use TLS"
+        end
+        @cert_bundle ||= tls_conf.cert_bundle
+      end
+    end
+  end
+end

--- a/lib/logstash-logger/device/kafka_new.rb
+++ b/lib/logstash-logger/device/kafka_new.rb
@@ -21,6 +21,7 @@ module LogStashLogger
         def invalid?
           !valid?
         end
+
         private
 
         def cert_params_as_hash
@@ -45,7 +46,6 @@ module LogStashLogger
 
       attr_reader :topic, :brokers, :cert_bundle, :kafka_tls_configurator,
         :client_id
-
 
       def initialize(opts = {}, kafka_tls_configurator = TLSConfiguration)
         require 'ruby-kafka'

--- a/lib/logstash-logger/device/kafka_new.rb
+++ b/lib/logstash-logger/device/kafka_new.rb
@@ -62,15 +62,17 @@ module LogStashLogger
         @connection ||= ::Kafka.new(kafka_client_connection_hash)
       end
 
-      def write_one(message, topic=@topic)
+      def write_one(message, topic=nil)
+        topic ||= @topic
         write_messages_to_broker_and_deliver do |producer|
           producer.produce(message, topic: topic)
         end
       end
 
-      def write_batch(messages, topic = @topic)
+      def write_batch(messages, topic=nil)
+        topic ||= @topic
         write_messages_to_broker_and_deliver do |producer|
-          messages.each {|message| producer.produce(message, topic: topic) }
+          messages.each {|msg| producer.produce(msg, topic: topic) }
         end
       end
 
@@ -83,9 +85,9 @@ module LogStashLogger
       end
 
       def kafka_client_connection_hash
-      { seed_brokers: @brokers,
-        client_id: @client_id,
-      }.merge(@cert_bundle)
+        { seed_brokers: @brokers,
+          client_id: @client_id,
+        }.merge(@cert_bundle)
       end
 
       def raise_no_topic_set!

--- a/lib/logstash-logger/version.rb
+++ b/lib/logstash-logger/version.rb
@@ -1,3 +1,3 @@
 module LogStashLogger
-  VERSION = "0.19.2"
+  VERSION = "0.19.3"
 end

--- a/logstash-logger.gemspec
+++ b/logstash-logger.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |gem|
   end
   gem.add_development_dependency 'redis'
   gem.add_development_dependency 'poseidon'
+  gem.add_development_dependency 'ruby-kafka'
 
   if RUBY_VERSION < '2' || defined?(JRUBY_VERSION)
     gem.add_development_dependency 'SyslogLogger'

--- a/spec/device/kafka_new_spec.rb
+++ b/spec/device/kafka_new_spec.rb
@@ -11,8 +11,6 @@ describe LogStashLogger::Device::KafkaNew::TLSConfiguration do
       }
     end
 
-
-
     context "when complete params are passed in" do
       let(:instance) { described_class.new(complete_bundle) }
 
@@ -53,7 +51,6 @@ describe LogStashLogger::Device::KafkaNew::TLSConfiguration do
       expect(subject.invalid?).to be_falsey
     end
   end
-
 end
 
 describe LogStashLogger::Device::KafkaNew do
@@ -99,7 +96,6 @@ describe LogStashLogger::Device::KafkaNew do
         }.to raise_error(ArgumentError)
       end
     end
-
 
     context "Client Introspection" do
       # YUCK! ruby-kafka does not presently allow reading certain variables

--- a/spec/device/kafka_new_spec.rb
+++ b/spec/device/kafka_new_spec.rb
@@ -1,0 +1,156 @@
+require 'logstash-logger'
+
+describe LogStashLogger::Device::KafkaNew::TLSConfiguration do
+  context "with TLS" do
+    let(:complete_bundle) do
+      # NOTE these keys are obviously fake. We don't actually make connections
+      {
+        ssl_ca_cert: "----BEGIN CERT---- lkajdslkajdsjk ----END CERT---",
+        ssl_client_cert:      "----BEGIN CERT---- lkajdslkajdsjk ----END CERT---",
+        ssl_client_cert_key: "----PRIVATE---- lkajdslkajdsjk ----PRIVATE---",
+      }
+    end
+
+    context "when complete params are passed in" do
+      let(:instance) { described_class.new(complete_bundle) }
+
+      it "returns an empty hash when no ssl params are initialized" do
+        expect(instance.cert_bundle).to_not be_empty
+        expect(instance.valid?).to be_truthy
+      end
+    end
+
+    context "when incomplete params are passed in" do
+      [:ssl_ca_cert, :ssl_client_cert, :ssl_client_cert_key].each do |param|
+        it "fails with an ArgumentError when #{param} no provided" do
+          opts = complete_bundle
+          opts[param] = nil
+          instance = described_class.new(opts)
+          expect(instance.cert_bundle).to be_empty
+          expect(instance.valid?).to be_falsey
+        end
+      end
+    end
+  end
+
+  context "without TLS" do
+    let(:instance) { subject }
+
+    it "returns an empty hash when no ssl params are initialized" do
+      expect(instance.cert_bundle).to be_empty
+      expect(instance.valid?).to be_truthy
+    end
+  end
+
+  context "#invalid?" do
+    it 'is just the opposite of valid?' do
+      expect(subject).to receive(:valid?).and_return(false)
+      expect(subject.invalid?).to be_truthy
+
+      expect(subject).to receive(:valid?).and_return(true)
+      expect(subject.invalid?).to be_falsey
+    end
+  end
+
+end
+
+describe LogStashLogger::Device::KafkaNew do
+  include_context 'device'
+
+  let(:broker_hosts) { "localhost:9300 localhost:9232" }
+  let(:instance) { LogStashLogger::Device::KafkaNew.new({brokers: broker_hosts}) }
+
+  describe "initializing" do
+    context "brokers" do
+      context "when array" do
+        it "sets the brokers array to @brokers" do
+          brokers = %w(localhost:9300 localhost:9232)
+          instance = LogStashLogger::Device::KafkaNew.new({brokers: brokers})
+
+          expect(instance.brokers).to be_kind_of Array
+          expect(instance.brokers.length).to eql(2)
+        end
+
+        it 'sets the brokers to an array if a string is passed in' do
+          brokers = "localhost:9300 localhost:9232"
+          instance = LogStashLogger::Device::KafkaNew.new({brokers: brokers})
+          expect(instance.brokers).to be_kind_of Array
+          expect(instance.brokers.length).to eql(2)
+        end
+      end
+    end
+
+    context "topic" do
+      it 'sets the topic to the option provided' do
+        instance = described
+      end
+    end
+
+    context "cert bundle" do
+      # YUCK! ruby-kafka does not presently allow reading certain variables
+      module ::Kafka
+        class Client
+          attr_reader :connection_builder
+        end
+      end
+
+
+      module ::Kafka
+        class ConnectionBuilder
+          attr_reader :ssl_context
+        end
+      end
+
+      let(:complete_bundle) do
+        # NOTE these keys are obviously fake. We don't actually make connections
+        {
+          ssl_ca_cert: "----BEGIN CERT---- lkajdslkajdsjk ----END CERT---",
+          ssl_client_cert:      "----BEGIN CERT---- lkajdslkajdsjk ----END CERT---",
+          ssl_client_cert_key: "----PRIVATE---- lkajdslkajdsjk ----PRIVATE---",
+        }
+      end
+
+      context "no certs" do
+        it 'creates a connection without an ssl_context' do
+          connection = instance.connect
+          expect(connection.connection_builder.ssl_context).to be_nil
+        end
+      end
+
+      context "partial certs passed in" do
+        it 'fails if the complete cert suite is not passed in' do
+          [:ssl_ca_cert, :ssl_client_cert, :ssl_client_cert_key].each do |param|
+            opts = complete_bundle.merge(brokers: broker_hosts)
+            opts[param] = nil
+            expect {
+              LogStashLogger::Device::KafkaNew.new(opts).connect
+            }.to raise_error( ArgumentError )
+          end
+        end
+      end
+
+      context "complete cert bundle" do
+
+        it 'correctly passes in the cert bundle to the Kafka Client' do
+          opts = complete_bundle.merge(brokers: broker_hosts)
+
+          expect_any_instance_of(::Kafka::Client).to receive(:build_ssl_context) 
+            .with(opts[:ssl_ca_cert], opts[:ssl_client_cert], opts[:ssl_client_cert_key])
+            .and_return(true)
+
+          LogStashLogger::Device::KafkaNew.new(opts).connect
+        end
+      end
+    end
+  end
+
+  describe "connecting" do
+    context "without certs" do
+      it "creates a connection object" do
+        # watch out for naming conflicts with poseidon!
+        # Both gems 'own' the namespace 'Kafka'
+        expect(instance.connect).to be_kind_of ::Kafka::Client
+      end
+    end
+  end
+end


### PR DESCRIPTION
The current dependency in this gem to support Kafka is no longer supported. This was brought up in #100 . 

This PR updates to a supported version of Kafka in ruby.

I've done some non-standard things in this PR to maintain backwards compatibility in order to avoid a major version bump and avoid falling into a backwards compatibility nightmare.

That said, a future version of this gem should be planned that completely removes the old Kafka implementation. I did my best to segment the code in such a way that the removal is straightforward.

As a bonus (and because of my own needs) the Kafka device will also support a TLS connection.