### PR TITLE
Add missing require for URI

### DIFF
--- a/lib/logstash-logger/device.rb
+++ b/lib/logstash-logger/device.rb
@@ -37,6 +37,7 @@ module LogStashLogger
 
     def self.parse_uri_config(opts)
       if uri = opts[:uri]
+        require 'uri'
         parsed = ::URI.parse(uri)
         {type: parsed.scheme, host: parsed.host, port: parsed.port, path: parsed.path}
       end


### PR DESCRIPTION
Without this line, I am not able to add URI specific links.

```
require 'logstash-logger'
logger = LogStashLogger.new(uri: "tcp://example.com:5001")
```

Fails with

```
/Users/bis/.gem/ruby/2.3.3/gems/logstash-logger-0.20.0/lib/logstash-logger/device.rb:40:in `parse_uri_config': uninitialized constant URI (NameError)
        from /Users/bis/.gem/ruby/2.3.3/gems/logstash-logger-0.20.0/lib/logstash-logger/device.rb:28:in `build_device'
        from /Users/bis/.gem/ruby/2.3.3/gems/logstash-logger-0.20.0/lib/logstash-logger/device.rb:24:in `new'
        from /Users/bis/.gem/ruby/2.3.3/gems/logstash-logger-0.20.0/lib/logstash-logger/logger.rb:67:in `build_default_logger'
        from /Users/bis/.gem/ruby/2.3.3/gems/logstash-logger-0.20.0/lib/logstash-logger/logger.rb:57:in `build_logger'
        from /Users/bis/.gem/ruby/2.3.3/gems/logstash-logger-0.20.0/lib/logstash-logger/logger.rb:10:in `new'
        from test.rb:2:in `<main>'
```