### PR TITLE
Merge top level configuration

### DIFF
--- a/lib/logstash-logger/device/multi_delegator.rb
+++ b/lib/logstash-logger/device/multi_delegator.rb
@@ -10,14 +10,16 @@ module LogStashLogger
 
       def initialize(opts)
         @io = self
-        @devices = create_devices(opts[:outputs])
+        @devices = create_devices(opts)
         self.class.delegate(:write, :close, :close!, :flush)
       end
 
       private
 
       def create_devices(opts)
-        opts.map do |device_opts|
+        output_configurations = opts.delete(:outputs)
+        output_configurations.map do |device_opts|
+          device_opts = opts.merge(device_opts)
           Device.new(device_opts)
         end
       end

--- a/lib/logstash-logger/logger.rb
+++ b/lib/logstash-logger/logger.rb
@@ -72,7 +72,7 @@ module LogStashLogger
   end
 
   def self.build_multi_logger(opts)
-    output_configurations = opts.delete(:outputs)
+    output_configurations = opts.delete(:outputs) || []
     loggers = output_configurations.map do |config|
       logger_opts = opts.merge(config)
       build_logger(logger_opts)

--- a/lib/logstash-logger/logger.rb
+++ b/lib/logstash-logger/logger.rb
@@ -72,7 +72,11 @@ module LogStashLogger
   end
 
   def self.build_multi_logger(opts)
-    loggers = opts[:outputs].map { |logger_opts| build_logger(logger_opts) }
+    output_configurations = opts.delete(:outputs)
+    loggers = output_configurations.map do |config|
+      logger_opts = opts.merge(config)
+      build_logger(logger_opts)
+    end
     MultiLogger.new(loggers)
   end
 

--- a/spec/constructor_spec.rb
+++ b/spec/constructor_spec.rb
@@ -1,0 +1,28 @@
+require 'logstash-logger'
+
+describe LogStashLogger do
+  describe ".new" do
+    it "returns a Logger instance" do
+      expect(LogStashLogger.new(type: :stdout)).to be_a ::Logger
+    end
+
+    context "type: :multi_logger" do
+      it "returns an instance of LogStashLogger::MultiLogger" do
+        expect(LogStashLogger.new(type: :multi_logger)).to be_a LogStashLogger::MultiLogger
+      end
+
+      it "merges top level configuration into each logger" do
+        logger = LogStashLogger.new(type: :multi_logger, port: 1234, outputs: [ { type: :tcp  }, { type: :udp } ])
+        logger.loggers.each do |logger|
+          expect(logger.device.port).to eq(1234)
+        end
+      end
+    end
+
+    context "type: :syslog" do
+      it "returns a Syslog::Logger instance" do
+        expect(LogStashLogger.new(type: :syslog)).to be_a ::Syslog::Logger
+      end
+    end
+  end
+end

--- a/spec/constructor_spec.rb
+++ b/spec/constructor_spec.rb
@@ -18,11 +18,5 @@ describe LogStashLogger do
         end
       end
     end
-
-    context "type: :syslog" do
-      it "returns a Syslog::Logger instance" do
-        expect(LogStashLogger.new(type: :syslog)).to be_a ::Syslog::Logger
-      end
-    end
   end
 end

--- a/spec/device/multi_delegator_spec.rb
+++ b/spec/device/multi_delegator_spec.rb
@@ -12,4 +12,20 @@ describe LogStashLogger::Device::MultiDelegator do
 
     subject.write("test")
   end
+
+  describe ".new" do
+    it "merges top level configuration to each output" do
+      logger = described_class.new(
+        port: 1234,
+        outputs: [
+          { type: :udp },
+          { type: :tcp }
+        ]
+      )
+
+      logger.devices.each do |device|
+        expect(device.port).to eq(1234)
+      end
+    end
+  end
 end


### PR DESCRIPTION
When constructing a `MultiLogger` or `MultiDelegator`, configuration options at the top level are ignored. This behavior is a bit surprising and unexpected. This fixes the issue by merging output configurations into the top level configuration before passing the configuration to build each output.

Fixes #106.