### PR TITLE
Use OJ for JSON

### DIFF
--- a/lib/logstash-logger.rb
+++ b/lib/logstash-logger.rb
@@ -6,6 +6,7 @@ require 'logstash-logger/device'
 
 require 'logstash-logger/logger'
 require 'logstash-logger/formatter'
+require 'logstash-logger/encoder'
 require 'logstash-logger/configuration'
 
 require 'logstash-logger/railtie' if defined?(Rails::Railtie)

--- a/lib/logstash-logger/encoder.rb
+++ b/lib/logstash-logger/encoder.rb
@@ -1,0 +1,53 @@
+module LogStashLogger
+  module Encoder
+    DEFAULT_ENCODER = :to_json
+
+    autoload :JsonGenerate, 'logstash-logger/encoder/json_generate'
+    autoload :ToJson, 'logstash-logger/encoder/to_json'
+
+    def self.instance
+      @instance ||= new(@global_encoder_type)
+    end
+
+    def self.global_encoder_type= (encoder_type)
+      if @global_encoder_type != encoder_type
+        @instance = nil
+        @global_encoder_type = encoder_type
+      end
+    end
+
+    def self.new(encoder_type)
+      build_encoder(encoder_type)
+    end
+
+    def self.build_encoder(encoder_type)
+      encoder_type ||= DEFAULT_ENCODER
+
+      encoder = if custom_encoder_instance?(encoder_type)
+        encoder_type
+      elsif custom_encoder_class?(encoder_type)
+        encoder_type.new
+      else
+        encoder_klass(encoder_type).new
+      end
+
+      encoder
+    end
+
+    def self.encoder_klass(encoder_type)
+      case encoder_type.to_sym
+      when :to_json then ToJson
+      when :json_generate then JsonGenerate
+      else fail ArgumentError, 'Invalid encoder'
+      end
+    end
+
+    def self.custom_encoder_instance?(encoder_type)
+      encoder_type.respond_to?(:call)
+    end
+
+    def self.custom_encoder_class?(encoder_type)
+      encoder_type.is_a?(Class) && encoder_type.method_defined?(:call)
+    end
+  end
+end

--- a/lib/logstash-logger/encoder/json_generate.rb
+++ b/lib/logstash-logger/encoder/json_generate.rb
@@ -1,0 +1,9 @@
+module LogStashLogger
+  module Encoder
+    class JsonGenerate
+      def call(event)
+        JSON.generate(event)
+      end
+    end
+  end
+end

--- a/lib/logstash-logger/encoder/to_json.rb
+++ b/lib/logstash-logger/encoder/to_json.rb
@@ -1,0 +1,9 @@
+module LogStashLogger
+  module Encoder
+    class ToJson
+      def call(event)
+        event.to_json
+      end
+    end
+  end
+end

--- a/lib/logstash-logger/formatter/json.rb
+++ b/lib/logstash-logger/formatter/json.rb
@@ -3,7 +3,7 @@ module LogStashLogger
     class Json < Base
       def call(severity, time, progname, message)
         super
-        @event.to_json
+        LogStashLogger::Encoder.instance.call(@event)
       end
     end
   end

--- a/lib/logstash-logger/formatter/json_lines.rb
+++ b/lib/logstash-logger/formatter/json_lines.rb
@@ -3,7 +3,7 @@ module LogStashLogger
     class JsonLines < Base
       def call(severity, time, progname, message)
         super
-        "#{@event.to_json}\n"
+        "#{LogStashLogger::Encoder.instance.call(@event)}\n"
       end
     end
   end

--- a/lib/logstash-logger/version.rb
+++ b/lib/logstash-logger/version.rb
@@ -1,3 +1,3 @@
 module LogStashLogger
-  VERSION = "0.22.1"
+  VERSION = "0.22.2"
 end


### PR DESCRIPTION
This is primitive implementation and will not work with JVM. But we can use oj optionally when it is available. What your thoughts? Am I missing something here?

Maybe we should provide something like `json_engine` config. 

Ticket: #117 