### PR TITLE
Add support for AWS Firehose

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ writing to a file or syslog since Logstash can receive the structured data direc
 ## Features
 
 * Can write directly to a logstash listener over a UDP or TCP/SSL connection.
-* Can write to a file, Redis, Kafka, Kinesis, a unix socket, syslog, stdout, or stderr.
+* Can write to a file, Redis, Kafka, Kinesis, Firehose, a unix socket, syslog, stdout, or stderr.
 * Logger can take a string message, a hash, a `LogStash::Event`, an object, or a JSON string as input.
 * Events are automatically populated with message, timestamp, host, and severity.
 * Writes in logstash JSON format, but supports other formats as well.
@@ -503,6 +503,30 @@ Add the aws-sdk gem to your Gemfile:
 config.logstash.type = :kinesis
 
 # Optional, will default to the 'logstash' stream
+config.logstash.stream = 'my-stream-name'
+
+# Optional, will default to 'us-east-1'
+config.logstash.aws_region = 'us-west-2'
+
+# Optional, will default to the AWS_ACCESS_KEY_ID environment variable
+config.logstash.aws_access_key_id = 'ASKASKHLD12341'
+
+# Optional, will default to the AWS_SECRET_ACCESS_KEY environment variable
+config.logstash.aws_secret_access_key = 'ASKASKHLD1234123412341234'
+
+```
+
+#### Firehose
+
+Add the aws-sdk gem to your Gemfile:
+
+    gem 'aws-sdk'
+
+```ruby
+# Required
+config.logstash.type = :firehose
+
+# Optional, will default to the 'logstash' delivery stream
 config.logstash.stream = 'my-stream-name'
 
 # Optional, will default to 'us-east-1'

--- a/lib/logstash-logger/device.rb
+++ b/lib/logstash-logger/device.rb
@@ -13,6 +13,7 @@ module LogStashLogger
     autoload :Redis, 'logstash-logger/device/redis'
     autoload :Kafka, 'logstash-logger/device/kafka'
     autoload :Kinesis, 'logstash-logger/device/kinesis'
+    autoload :Firehose, 'logstash-logger/device/firehose'
     autoload :File, 'logstash-logger/device/file'
     autoload :IO, 'logstash-logger/device/io'
     autoload :Stdout, 'logstash-logger/device/stdout'
@@ -53,6 +54,7 @@ module LogStashLogger
         when :redis then Redis
         when :kafka then Kafka
         when :kinesis then Kinesis
+        when :firehose then Firehose
         when :io then IO
         when :stdout then Stdout
         when :stderr then Stderr

--- a/lib/logstash-logger/device/aws_stream.rb
+++ b/lib/logstash-logger/device/aws_stream.rb
@@ -1,0 +1,25 @@
+module LogStashLogger
+  module Device
+    # A simple module to abstract common methods for AWS Kinesis and Firehose
+    module AwsStream
+
+      def with_connection
+        connect unless connected?
+        yield
+      rescue => e
+        log_error(e)
+        log_warning("giving up")
+        close(flush: false)
+      end
+
+      def write_one(message)
+        write_batch([message])
+      end
+
+      def close!
+        @io = nil
+      end
+    end
+  end
+end
+

--- a/lib/logstash-logger/device/aws_stream.rb
+++ b/lib/logstash-logger/device/aws_stream.rb
@@ -16,7 +16,7 @@ module LogStashLogger
         @aws_region = opts[:aws_region] || DEFAULT_REGION
         @stream = opts[:stream] || DEFAULT_STREAM
         @stream_class = nil
-        @recoverable_error_code = []
+        @recoverable_error_codes = []
       end
 
       def transform_message(message)
@@ -61,11 +61,11 @@ module LogStashLogger
           if !is_successful_response(resp)
             get_response_records(resp).each_with_index do |record, index|
               if @recoverable_error_codes.include?(record.error_code)
-                log_warning("Failed to post record to #{@stream_class.name} with error: #{record.error_code} #{record.error_message}")
+                log_warning("Failed to post record using #{@stream_class.name} with error: #{record.error_code} #{record.error_message}")
                 log_warning("Retrying")
                 write(records[index][:data])
               elsif !record.error_code.nil? && record.error_code != ''
-                log_error("Failed to post record to #{@stream_class.name} with error: #{record.error_code} #{record.error_message}")
+                log_error("Failed to post record using #{@stream_class.name} with error: #{record.error_code} #{record.error_message}")
               end
             end
           end

--- a/lib/logstash-logger/device/aws_stream.rb
+++ b/lib/logstash-logger/device/aws_stream.rb
@@ -1,5 +1,4 @@
 require 'aws-sdk'
-require 'logstash-logger/device/aws_stream'
 
 module LogStashLogger
   module Device

--- a/lib/logstash-logger/device/aws_stream.rb
+++ b/lib/logstash-logger/device/aws_stream.rb
@@ -1,7 +1,47 @@
+require 'aws-sdk'
+require 'logstash-logger/device/aws_stream'
+
 module LogStashLogger
   module Device
-    # A simple module to abstract common methods for AWS Kinesis and Firehose
-    module AwsStream
+    class AwsStream < Connectable
+
+      DEFAULT_REGION = 'us-east-1'
+      DEFAULT_STREAM = 'logstash'
+
+      attr_accessor :aws_region, :stream, :stream_class, :recoverable_error_codes
+
+      def initialize(opts)
+        super
+        @access_key_id = opts[:aws_access_key_id] || ENV['AWS_ACCESS_KEY_ID']
+        @secret_access_key = opts[:aws_secret_access_key] || ENV['AWS_SECRET_ACCESS_KEY']
+        @aws_region = opts[:aws_region] || DEFAULT_REGION
+        @stream = opts[:stream] || DEFAULT_STREAM
+        @stream_class = nil
+        @recoverable_error_code = []
+      end
+
+      def transform_message(message)
+        fail NotImplementedError
+      end
+
+      def put_records(records)
+        fail NotImplementedError
+      end
+
+      def is_successful_response(resp)
+        fail NotImplementedError
+      end
+
+      def get_response_records(resp)
+        fail NotImplementedError
+      end
+
+      def connect
+        @io = @stream_class.new(
+          region: @aws_region,
+          credentials: ::Aws::Credentials.new(@access_key_id, @secret_access_key)
+        )
+      end
 
       def with_connection
         connect unless connected?
@@ -12,6 +52,27 @@ module LogStashLogger
         close(flush: false)
       end
 
+      def write_batch(messages, group = nil)
+        records = messages.map{ |m| transform_message(m) }
+
+        with_connection do
+          resp = put_records(records)
+
+          # Put any failed records back into the buffer
+          if !is_successful_response(resp)
+            get_response_records(resp).each_with_index do |record, index|
+              if @recoverable_error_codes.include?(record.error_code)
+                log_warning("Failed to post record to #{@stream_class.name} with error: #{record.error_code} #{record.error_message}")
+                log_warning("Retrying")
+                write(records[index][:data])
+              elsif !record.error_code.nil? && record.error_code != ''
+                log_error("Failed to post record to #{@stream_class.name} with error: #{record.error_code} #{record.error_message}")
+              end
+            end
+          end
+        end
+      end
+
       def write_one(message)
         write_batch([message])
       end
@@ -19,6 +80,7 @@ module LogStashLogger
       def close!
         @io = nil
       end
+
     end
   end
 end

--- a/lib/logstash-logger/device/firehose.rb
+++ b/lib/logstash-logger/device/firehose.rb
@@ -4,15 +4,16 @@ require 'logstash-logger/device/aws_stream'
 module LogStashLogger
   module Device
     class Firehose < AwsStream
+      FIREHOSE_ERROR_CODES = [
+        "ServiceUnavailable",
+        "InternalFailure",
+        "ServiceUnavailableException"
+      ].freeze
 
       def initialize(opts)
         super
         @stream_class = ::Aws::Firehose::Client
-        @recoverable_error_codes = [
-          "ServiceUnavailable",
-          "InternalFailure",
-          "ServiceUnavailableException"
-        ].freeze
+        @recoverable_error_codes = FIREHOSE_ERROR_CODES
       end
 
       def transform_message(message)

--- a/lib/logstash-logger/device/firehose.rb
+++ b/lib/logstash-logger/device/firehose.rb
@@ -1,63 +1,40 @@
-require 'aws-sdk'
 require 'logstash-logger/device/aws_stream'
 
 module LogStashLogger
   module Device
-    class Firehose < Connectable
-      include Device::AwsStream
-
-      DEFAULT_REGION = 'us-east-1'
-      DEFAULT_STREAM = 'logstash'
-      RECOVERABLE_ERROR_CODES = [
-        "ServiceUnavailable",
-        "InternalFailure",
-        "ServiceUnavailableException"
-      ]
-
-      attr_accessor :aws_region, :stream
+    class Firehose < AwsStream
 
       def initialize(opts)
         super
-        @access_key_id = opts[:aws_access_key_id] || ENV['AWS_ACCESS_KEY_ID']
-        @secret_access_key = opts[:aws_secret_access_key] || ENV['AWS_SECRET_ACCESS_KEY']
-        @aws_region = opts[:aws_region] || DEFAULT_REGION
-        @stream = opts[:stream] || DEFAULT_STREAM
+        @stream_class = ::Aws::Firehose::Client
+        @recoverable_error_codes = [
+          "ServiceUnavailable",
+          "InternalFailure",
+          "ServiceUnavailableException"
+        ].freeze
       end
 
-      def connect
-        @io = ::Aws::Firehose::Client.new(
-          region: @aws_region,
-          credentials: ::Aws::Credentials.new(@access_key_id, @secret_access_key)
-        )
+      def transform_message(message)
+        {
+          data: message
+        }
       end
 
-      def write_batch(messages, group = nil)
-        firehose_records = messages.map do |message|
-          {
-            data: message,
-          }
-        end
-
-        with_connection do
-          resp = @io.put_record_batch({
-            records: firehose_records,
-            delivery_stream_name: @stream
-          })
-
-          # Put any failed records back into the buffer
-          if resp.failed_put_count != 0
-            resp.request_responses.each_with_index do |record, index|
-              if RECOVERABLE_ERROR_CODES.include?(record.error_code)
-                log_warning("Failed to post record to firehose with error: #{record.error_code} #{record.error_message}")
-                log_warning("Retrying")
-                write(firehose_records[index][:data])
-              elsif !record.error_code.nil? && record.error_code != ''
-                log_error("Failed to post record to firehose with error: #{record.error_code} #{record.error_message}")
-              end
-            end
-          end
-        end
+      def put_records(records)
+        @io.put_record_batch({
+          records: records,
+          delivery_stream_name: @stream
+        })
       end
+
+      def is_successful_response(resp)
+        resp.failed_put_count == 0
+      end
+
+      def get_response_records(resp)
+        resp.request_responses
+      end
+
     end
   end
 end

--- a/lib/logstash-logger/device/firehose.rb
+++ b/lib/logstash-logger/device/firehose.rb
@@ -1,3 +1,4 @@
+require 'aws-sdk'
 require 'logstash-logger/device/aws_stream'
 
 module LogStashLogger

--- a/lib/logstash-logger/device/firehose.rb
+++ b/lib/logstash-logger/device/firehose.rb
@@ -4,17 +4,12 @@ require 'logstash-logger/device/aws_stream'
 module LogStashLogger
   module Device
     class Firehose < AwsStream
-      FIREHOSE_ERROR_CODES = [
+      @stream_class = ::Aws::Firehose::Client
+      @recoverable_error_codes = [
         "ServiceUnavailable",
         "InternalFailure",
         "ServiceUnavailableException"
       ].freeze
-
-      def initialize(opts)
-        super
-        @stream_class = ::Aws::Firehose::Client
-        @recoverable_error_codes = FIREHOSE_ERROR_CODES
-      end
 
       def transform_message(message)
         {

--- a/lib/logstash-logger/device/firehose.rb
+++ b/lib/logstash-logger/device/firehose.rb
@@ -10,7 +10,8 @@ module LogStashLogger
       DEFAULT_STREAM = 'logstash'
       RECOVERABLE_ERROR_CODES = [
         "ServiceUnavailable",
-        "InternalFailure"
+        "InternalFailure",
+        "ServiceUnavailableException"
       ]
 
       attr_accessor :aws_region, :stream

--- a/lib/logstash-logger/device/kinesis.rb
+++ b/lib/logstash-logger/device/kinesis.rb
@@ -1,3 +1,4 @@
+require 'aws-sdk'
 require 'logstash-logger/device/aws_stream'
 
 module LogStashLogger

--- a/lib/logstash-logger/device/kinesis.rb
+++ b/lib/logstash-logger/device/kinesis.rb
@@ -4,18 +4,13 @@ require 'logstash-logger/device/aws_stream'
 module LogStashLogger
   module Device
     class Kinesis < AwsStream
-      KINESIS_ERROR_CODES = [
+      @stream_class = ::Aws::Kinesis::Client
+      @recoverable_error_codes = [
         "ServiceUnavailable",
         "Throttling",
         "RequestExpired",
         "ProvisionedThroughputExceededException"
       ].freeze
-
-      def initialize(opts)
-        super
-        @stream_class = ::Aws::Kinesis::Client
-        @recoverable_error_codes = KINESIS_ERROR_CODES
-      end
 
       def transform_message(message)
         {

--- a/lib/logstash-logger/device/kinesis.rb
+++ b/lib/logstash-logger/device/kinesis.rb
@@ -4,16 +4,17 @@ require 'logstash-logger/device/aws_stream'
 module LogStashLogger
   module Device
     class Kinesis < AwsStream
+      KINESIS_ERROR_CODES = [
+        "ServiceUnavailable",
+        "Throttling",
+        "RequestExpired",
+        "ProvisionedThroughputExceededException"
+      ].freeze
 
       def initialize(opts)
         super
         @stream_class = ::Aws::Kinesis::Client
-        @recoverable_error_codes = [
-          "ServiceUnavailable",
-          "Throttling",
-          "RequestExpired",
-          "ProvisionedThroughputExceededException"
-        ].freeze
+        @recoverable_error_codes = KINESIS_ERROR_CODES
       end
 
       def transform_message(message)

--- a/lib/logstash-logger/device/kinesis.rb
+++ b/lib/logstash-logger/device/kinesis.rb
@@ -1,65 +1,42 @@
-require 'aws-sdk'
 require 'logstash-logger/device/aws_stream'
 
 module LogStashLogger
   module Device
-    class Kinesis < Connectable
-      include Device::AwsStream
-
-      DEFAULT_REGION = 'us-east-1'
-      DEFAULT_STREAM = 'logstash'
-      RECOVERABLE_ERROR_CODES = [
-        "ServiceUnavailable",
-        "Throttling",
-        "RequestExpired",
-        "ProvisionedThroughputExceededException"
-      ]
-
-      attr_accessor :aws_region, :stream
+    class Kinesis < AwsStream
 
       def initialize(opts)
         super
-        @access_key_id = opts[:aws_access_key_id] || ENV['AWS_ACCESS_KEY_ID']
-        @secret_access_key = opts[:aws_secret_access_key] || ENV['AWS_SECRET_ACCESS_KEY']
-        @aws_region = opts[:aws_region] || DEFAULT_REGION
-        @stream = opts[:stream] || DEFAULT_STREAM
+        @stream_class = ::Aws::Kinesis::Client
+        @recoverable_error_codes = [
+          "ServiceUnavailable",
+          "Throttling",
+          "RequestExpired",
+          "ProvisionedThroughputExceededException"
+        ].freeze
       end
 
-      def connect
-        @io = ::Aws::Kinesis::Client.new(
-          region: @aws_region,
-          credentials: ::Aws::Credentials.new(@access_key_id, @secret_access_key)
-        )
+      def transform_message(message)
+        {
+          data: message,
+          partition_key: SecureRandom.uuid
+        }
       end
 
-      def write_batch(messages, group = nil)
-        kinesis_records = messages.map do |message|
-          {
-            data: message,
-            partition_key: SecureRandom.uuid
-          }
-        end
-
-        with_connection do
-          resp = @io.put_records({
-            records: kinesis_records,
-            stream_name: @stream
-          })
-
-          # Put any failed records back into the buffer
-          if resp.failed_record_count != 0
-            resp.records.each_with_index do |record, index|
-              if RECOVERABLE_ERROR_CODES.include?(record.error_code)
-                log_warning("Failed to post record to kinesis with error: #{record.error_code} #{record.error_message}")
-                log_warning("Retrying")
-                write(kinesis_records[index][:data])
-              elsif !record.error_code.nil? && record.error_code != ''
-                log_error("Failed to post record to kinesis with error: #{record.error_code} #{record.error_message}")
-              end
-            end
-          end
-        end
+      def put_records(records)
+        @io.put_records({
+          records: records,
+          stream_name: @stream
+        })
       end
+
+      def is_successful_response(resp)
+        resp.failed_record_count == 0
+      end
+
+      def get_response_records(resp)
+        resp.records
+      end
+
     end
   end
 end

--- a/spec/device/firehose_spec.rb
+++ b/spec/device/firehose_spec.rb
@@ -1,0 +1,45 @@
+require 'logstash-logger'
+
+describe LogStashLogger::Device::Kinesis do
+  include_context 'device'
+
+  let(:client) { double("Aws::Firehose::Client") }
+
+  before(:each) do
+    allow(Aws::Firehose::Client).to receive(:new) { client }
+  end
+
+  it "writes to a Firehose stream" do
+    response = ::Aws::Firehose::Types::PutRecordBatchOutput.new
+    response.failed_put_count = 0
+    response.request_responses = []
+    expect(client).to receive(:put_record_batch) { response }
+    firehose_device.write "foo"
+
+    expect(firehose_device).to be_connected
+    firehose_device.close!
+    expect(firehose_device).not_to be_connected
+  end
+
+  it "it puts records with recoverable errors back in the buffer" do
+    failed_record = ::Aws::Firehose::Types::PutRecordBatchResponseEntry.new
+    failed_record.error_code = "ServiceUnavailable"
+    failed_record.error_message = "ServiceUnavailable"
+    response = ::Aws::Firehose::Types::PutRecordBatchOutput.new
+    response.failed_put_count = 1
+    response.request_responses = [failed_record]
+
+    expect(client).to receive(:put_record_batch) { response }
+    expect(firehose_device).to receive(:write).with("foo")
+
+    firehose_device.write_one "foo"
+  end
+
+  it "defaults the AWS region to us-east-1" do
+    expect(firehose_device.aws_region).to eq('us-east-1')
+  end
+
+  it "defaults the Firehose stream to logstash" do
+    expect(firehose_device.stream).to eq('logstash')
+  end
+end

--- a/spec/device/firehose_spec.rb
+++ b/spec/device/firehose_spec.rb
@@ -23,8 +23,8 @@ describe LogStashLogger::Device::Kinesis do
 
   it "it puts records with recoverable errors back in the buffer" do
     failed_record = ::Aws::Firehose::Types::PutRecordBatchResponseEntry.new
-    failed_record.error_code = "ServiceUnavailable"
-    failed_record.error_message = "ServiceUnavailable"
+    failed_record.error_code = "InternalFailure"
+    failed_record.error_message = "InternalFailure"
     response = ::Aws::Firehose::Types::PutRecordBatchOutput.new
     response.failed_put_count = 1
     response.request_responses = [failed_record]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,6 +62,7 @@ RSpec.shared_context 'device' do
   let(:redis_device) { LogStashLogger::Device.new(type: :redis, sync: true) }
   let(:kafka_device) { LogStashLogger::Device.new(type: :kafka, sync: true) }
   let(:kinesis_device) { LogStashLogger::Device.new(type: :kinesis, sync: true) }
+  let(:firehose_device) { LogStashLogger::Device.new(type: :firehose, sync: true) }
 
   let(:outputs) { [{type: :stdout}, {type: :io, io: io}] }
   let(:multi_delegator_device) { LogStashLogger::Device.new(type: :multi_delegator, outputs: outputs) }


### PR DESCRIPTION
AWS Firehose allow direct streaming data to AWS elastic search service. This would allow a seamless delivery of log from hosting machine to ES.

This is mostly mimic what the `Kinesis` device is doing. 