### PR TITLE
Rails 5.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ gemfile:
   - gemfiles/rails_4.1.gemfile
   - gemfiles/rails_4.2.gemfile
   - gemfiles/rails_5.0.gemfile
+  - gemfiles/rails_5.1.gemfile
 matrix:
   allow_failures:
     - rvm: rubinius-3

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ matrix:
   allow_failures:
     - rvm: rubinius-3
     - rvm: 2.4.1
-    - rvm: jruby-9.1.5.0
+      gemfile: gemfiles/rails_4.0.gemfile
+    - rvm: 2.4.1
+      gemfile: gemfiles/rails_4.1.gemfile
 addons:
   code_climate:
     repo_token: 4d712355fa2863c0f33f413eeede4e52cc221c4bc989a692d97574b1f6010b69

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,39 +5,20 @@ cache: bundler
 after_success:
   bundle exec codeclimate-test-reporter
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.9
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
-  - jruby-19mode
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
   - jruby-9.1.5.0
   - rubinius-3
 gemfile:
-  - gemfiles/rails_3.2.gemfile
   - gemfiles/rails_4.0.gemfile
   - gemfiles/rails_4.1.gemfile
   - gemfiles/rails_4.2.gemfile
   - gemfiles/rails_5.0.gemfile
 matrix:
-  exclude:
-    - rvm: 1.9.3
-      gemfile: gemfiles/rails_5.0.gemfile
-    - rvm: jruby-19mode
-      gemfile: gemfiles/rails_5.0.gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/rails_5.0.gemfile
-    - rvm: 2.1.9
-      gemfile: gemfiles/rails_5.0.gemfile
-    - rvm: 2.2.5
-      gemfile: gemfiles/rails_3.2.gemfile
-    - rvm: 2.3.1
-      gemfile: gemfiles/rails_3.2.gemfile
   allow_failures:
     - rvm: rubinius-3
-    - rvm: 2.4.0
-    - rvm: jruby-19mode
+    - rvm: 2.4.1
     - rvm: jruby-9.1.5.0
 addons:
   code_climate:

--- a/Appraisals
+++ b/Appraisals
@@ -1,6 +1,6 @@
-appraise "rails-3.2" do
-  gem "rails", "~> 3.2.18"
-end
+#appraise "rails-3.2" do
+  #gem "rails", "~> 3.2.18"
+#end
 
 appraise "rails-4.0" do
   gem "rails", "~> 4.0.0"
@@ -16,4 +16,8 @@ end
 
 appraise "rails-5.0" do
   gem "rails", "~> 5.0.0"
+end
+
+appraise "rails-5.1" do
+  gem "rails", "~> 5.1.0"
 end

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ end
 
 ## Rails Integration
 
-Verified to work with both Rails 3, 4, and 5.
+Supports Rails 4 and 5.
 
 By default, every Rails log message will be written to logstash in `LogStash::Event` JSON format.
 
@@ -690,11 +690,11 @@ end
 
 Verified to work with:
 
-* MRI Ruby 1.9.3, 2.0, 2.1, 2.2, 2.3
-* JRuby 1.7, 9.0
+* MRI Ruby 2.2, 2.3, 2.4
+* JRuby 9.0
 * Rubinius
 
-Ruby 1.8.7 is not supported.
+Ruby versions < 2.2 are EOL'ed and no longer supported.
 
 ## What type of logger should I use?
 

--- a/gemfiles/rails_4.0.gemfile
+++ b/gemfiles/rails_4.0.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "codecov", :require => false, :group => :test
-gem "codeclimate-test-reporter", :group => :test, :require => nil
+gem "codecov", require: false, group: :test
+gem "codeclimate-test-reporter", group: :test, require: nil
 gem "rails", "~> 4.0.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "codecov", :require => false, :group => :test
-gem "codeclimate-test-reporter", :group => :test, :require => nil
+gem "codecov", require: false, group: :test
+gem "codeclimate-test-reporter", group: :test, require: nil
 gem "rails", "~> 4.1.1"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "codecov", :require => false, :group => :test
-gem "codeclimate-test-reporter", :group => :test, :require => nil
+gem "codecov", require: false, group: :test
+gem "codeclimate-test-reporter", group: :test, require: nil
 gem "rails", "~> 5.0.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -4,6 +4,6 @@ source "https://rubygems.org"
 
 gem "codecov", require: false, group: :test
 gem "codeclimate-test-reporter", group: :test, require: nil
-gem "rails", "~> 4.2.0"
+gem "rails", "~> 5.1.0"
 
 gemspec path: "../"

--- a/logstash-logger.gemspec
+++ b/logstash-logger.gemspec
@@ -21,23 +21,12 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'logstash-event', '~> 1.2'
 
   gem.add_development_dependency 'rails'
-  if RUBY_VERSION < '2'
-    gem.add_development_dependency 'mime-types', '< 3'
-  end
   gem.add_development_dependency 'redis'
   gem.add_development_dependency 'poseidon'
   gem.add_development_dependency 'aws-sdk'
 
-  if RUBY_VERSION < '2' || defined?(JRUBY_VERSION)
+  if defined?(JRUBY_VERSION)
     gem.add_development_dependency 'SyslogLogger'
-  end
-
-  if RUBY_VERSION < '2'
-    gem.add_development_dependency 'json', '~> 1.8'
-  end
-
-  if RUBY_VERSION < '2.1'
-    gem.add_development_dependency 'nokogiri', '~> 1.6.8'
   end
 
   gem.add_development_dependency 'rspec', '>= 3'


### PR DESCRIPTION
Also drops support for Rails 3.2, and Ruby < 2.2 since these have been EOL'ed.