### PR TITLE
Skip message truncating when there is no message field

### DIFF
--- a/lib/logstash-logger/formatter/base.rb
+++ b/lib/logstash-logger/formatter/base.rb
@@ -57,7 +57,7 @@ module LogStashLogger
           event.timestamp = event.timestamp.iso8601(3)
         end
 
-        if LogStashLogger.configuration.max_message_size
+        if LogStashLogger.configuration.max_message_size && event['message']
           event['message'.freeze] = event['message'.freeze].byteslice(0, LogStashLogger.configuration.max_message_size)
         end
 

--- a/spec/formatter/base_spec.rb
+++ b/spec/formatter/base_spec.rb
@@ -68,5 +68,36 @@ describe LogStashLogger::Formatter::Base do
         expect(event.timestamp).to eq(time.iso8601(3))
       end
     end
+
+    describe "long messages" do
+
+      context "message field is present" do
+        let(:message) { long_message }
+
+        it "truncates long messages when max_message_size is set" do
+          LogStashLogger.configure do |config|
+            config.max_message_size = 2000
+          end
+
+          expect(event['message'].size).to eq(2000)
+        end
+      end
+
+      context "event without message field" do
+        let(:message) do
+          { 'test_field' => 'test', 'foo' => 'bar' }
+        end
+
+        it "still works" do
+          LogStashLogger.configure do |config|
+            config.max_message_size = 2000
+          end
+
+          expect(event['message']).to eq(nil)
+          expect(event['test_field']).to eq('test')
+          expect(event['foo']).to eq('bar')
+        end
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'pry'
+require 'securerandom'
 
 require 'simplecov'
 SimpleCov.start
@@ -102,6 +103,7 @@ RSpec.shared_context 'formatter' do
   let(:time) { Time.now }
   let(:progname) { "ruby" }
   let(:message) { "foo" }
+  let(:long_message) { SecureRandom.hex(65537) }
   let(:hostname) { Socket.gethostname }
   let(:formatted_message) do
     subject.call(severity, time, progname, message)


### PR DESCRIPTION
Hi guys!
I was faced with the following problem:
I'm sending messages and pure JSON objects through UDP, and sometimes some messages can be very large. So i've decided to use `max_message_size` option but i've encountered another problem:
```
Failure/Error: event['message'.freeze] = event['message'.freeze].byteslice(0, LogStashLogger.configuration.max_message_size)
     
     NoMethodError:
       undefined method `byteslice' for nil:NilClass
     # ./lib/logstash-logger/formatter/base.rb:61:in `build_event'
     # ./lib/logstash-logger/formatter/base.rb:18:in `call'
```
cause there is no `message`-field in the JSON-objects.
