### PR TITLE
Allow type to be a string for multi_logger and syslog

### DIFF
--- a/lib/logstash-logger/logger.rb
+++ b/lib/logstash-logger/logger.rb
@@ -48,7 +48,8 @@ module LogStashLogger
   def self.build_logger(opts)
     formatter = Formatter.new(opts.delete(:formatter), customize_event: opts.delete(:customize_event))
 
-    logger = case opts[:type]
+    logger_type = opts[:type].is_a?(String) ? opts[:type].to_sym : opts[:type]
+    logger = case logger_type
     when :multi_logger
       build_multi_logger(opts)
     when :syslog

--- a/logstash-logger.gemspec
+++ b/logstash-logger.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'wwtd'
   gem.add_development_dependency 'appraisal'
+  gem.add_development_dependency 'rubocop', '0.4.6'
 end

--- a/spec/syslog_spec.rb
+++ b/spec/syslog_spec.rb
@@ -1,25 +1,34 @@
 require 'logstash-logger'
 
 describe LogStashLogger do
-  context "Syslog" do
-    let(:program_name) { "MyApp" }
-    let(:facility) { 128 } #Syslog::LOG_LOCAL0 }
+  let(:program_name) { 'MyApp' }
+  let(:facility) { 128 } #Syslog::LOG_LOCAL0 }
+
+  context 'Syslog' do
     subject { LogStashLogger.new(type: :syslog, program_name: program_name, facility: facility) }
     let(:syslog) { subject.class.class_variable_get(:@@syslog) }
 
     it { is_expected.to be_a Syslog::Logger }
 
-    it "writes formatted messages to syslog" do
+    it 'writes formatted messages to syslog' do
       expect(syslog).to receive(:log)
-      subject.info("test")
+      subject.info('test')
     end
 
-    it "sets the syslog identity" do
+    it 'sets the syslog identity' do
       expect(syslog.ident).to eq(program_name)
     end
 
-    it "sets the default facility if supported" do
+    it 'sets the default facility if supported' do
       expect(subject.facility).to eq(facility) if subject.respond_to?(:facility)
+    end
+  end
+
+  context 'When logger type is a string' do
+    subject { LogStashLogger.new(type: 'syslog', program_name: program_name, facility: facility) }
+
+    it 'creates syslog logger even if type is not a symbol' do
+      expect(subject).to be_a(LogStashLogger)
     end
   end
 end


### PR DESCRIPTION
Now there is an inconsistency in creating loggers:

You can create logger with `type: 'file'`, but you will get an error if you would try to create a logger with `type: 'syslog'` or `type: 'multi_logger'`. Syslog and Multi_logger only accept symbol as a type.

I made logger creation the same for 'default logger' and for syslog and multi_logger.