### PR TITLE
Return `nil` from formatters' `#call` method if the logstash event has been cancelled

### DIFF
--- a/lib/logstash-logger/device/base.rb
+++ b/lib/logstash-logger/device/base.rb
@@ -15,7 +15,7 @@ module LogStashLogger
       end
 
       def write(message)
-        write_one(message)
+        write_one(message) unless message.nil?
       end
 
       def write_one(message)

--- a/lib/logstash-logger/device/connectable.rb
+++ b/lib/logstash-logger/device/connectable.rb
@@ -56,7 +56,7 @@ module LogStashLogger
       end
 
       def write(message)
-        buffer_receive message, @buffer_group
+        buffer_receive(message, @buffer_group) unless message.nil?
       end
 
       def flush(*args)

--- a/lib/logstash-logger/formatter/base.rb
+++ b/lib/logstash-logger/formatter/base.rb
@@ -14,11 +14,12 @@ module LogStashLogger
         super()
       end
 
-      def call(severity, time, progname, message)
-        @event = build_event(message, severity, time)
+      def call(severity, time, _progname, message)
+        event = build_event(message, severity, time)
+        format_event(event) unless event.cancelled?
       end
 
-      protected
+      private
 
       def build_event(message, severity, time)
         data = message
@@ -61,6 +62,10 @@ module LogStashLogger
           event['message'.freeze] = event['message'.freeze].byteslice(0, LogStashLogger.configuration.max_message_size)
         end
 
+        event
+      end
+
+      def format_event(event)
         event
       end
     end

--- a/lib/logstash-logger/formatter/cee.rb
+++ b/lib/logstash-logger/formatter/cee.rb
@@ -1,9 +1,10 @@
 module LogStashLogger
   module Formatter
     class Cee < Base
-      def call(severity, time, progname, message)
-        super
-        "@cee:#{@event.to_json}"
+      private
+
+      def format_event(event)
+        "@cee:#{event.to_json}"
       end
     end
   end

--- a/lib/logstash-logger/formatter/cee_syslog.rb
+++ b/lib/logstash-logger/formatter/cee_syslog.rb
@@ -2,18 +2,20 @@ module LogStashLogger
   module Formatter
     class CeeSyslog < Cee
       def call(severity, time, progname, message)
-        @cee = super
         @progname = progname
-
-        "#{facility}:#{@cee}\n"
+        super
       end
 
-      protected
+      private
 
-      def facility
-        @facility = "#{@event['host']}"
-        @facility << " #{@progname}" if @progname
-        @facility
+      def build_facility(host)
+        facility = host.dup
+        facility << " #{@progname}" if @progname
+        facility
+      end
+
+      def format_event(event)
+        "#{build_facility(event["host".freeze])}:#{super}\n"
       end
     end
   end

--- a/lib/logstash-logger/formatter/json.rb
+++ b/lib/logstash-logger/formatter/json.rb
@@ -1,9 +1,10 @@
 module LogStashLogger
   module Formatter
     class Json < Base
-      def call(severity, time, progname, message)
-        super
-        @event.to_json
+      private
+
+      def format_event(event)
+        event.to_json
       end
     end
   end

--- a/lib/logstash-logger/formatter/json_lines.rb
+++ b/lib/logstash-logger/formatter/json_lines.rb
@@ -1,9 +1,10 @@
 module LogStashLogger
   module Formatter
     class JsonLines < Base
-      def call(severity, time, progname, message)
-        super
-        "#{@event.to_json}\n"
+      private
+
+      def format_event(event)
+        "#{event.to_json}\n"
       end
     end
   end

--- a/lib/logstash-logger/formatter/logstash_event.rb
+++ b/lib/logstash-logger/formatter/logstash_event.rb
@@ -1,9 +1,6 @@
 module LogStashLogger
   module Formatter
     class LogStashEvent < Base
-      def call(severity, time, progname, message)
-        super
-      end
     end
   end
 end

--- a/spec/formatter/base_spec.rb
+++ b/spec/formatter/base_spec.rb
@@ -3,6 +3,28 @@ require 'logstash-logger'
 describe LogStashLogger::Formatter::Base do
   include_context "formatter"
 
+  describe "#call" do
+    context "when event is not cancelled" do
+      it "returns a formatted message" do
+        expect(subject).to receive(:format_event).once.with(instance_of(LogStash::Event)).and_call_original
+        expect(subject.call(severity, time, progname, message)).to be_a(LogStash::Event)
+      end
+    end
+
+    context "when event is cancelled" do
+      before(:each) do
+        LogStashLogger.configure do |config|
+          config.customize_event(&:cancel)
+        end
+      end
+
+      it "returns `nil`" do
+        expect(subject).not_to receive(:format_event)
+        expect(subject.call(severity, time, progname, message)).to be_nil
+      end
+    end
+  end
+
   describe "#build_event" do
     let(:event) { formatted_message }
 

--- a/spec/formatter/cee_syslog_spec.rb
+++ b/spec/formatter/cee_syslog_spec.rb
@@ -7,7 +7,7 @@ describe LogStashLogger::Formatter::CeeSyslog do
     let(:facility) { "facility" }
 
     before do
-      allow(subject).to receive(:facility).and_return(facility)
+      allow(subject).to receive(:build_facility).and_return(facility)
     end
 
     it "outputs a facility before the @cee" do
@@ -21,7 +21,7 @@ describe LogStashLogger::Formatter::CeeSyslog do
     end
   end
 
-  describe "#facility" do
+  describe "#build_facility" do
     let(:host) { Socket.gethostname }
 
     before do
@@ -29,14 +29,14 @@ describe LogStashLogger::Formatter::CeeSyslog do
     end
 
     it "includes hostname and progname" do
-      expect(subject.send(:facility)).to match(/\A#{host}\s#{progname}\z/)
+      expect(subject.send(:build_facility, host)).to match(/\A#{host}\s#{progname}\z/)
     end
 
     context "without progname" do
       let(:progname) { nil }
 
       it "only includes hostname" do
-        expect(subject.send(:facility)).to match(/\A#{host}\z/)
+        expect(subject.send(:build_facility, host)).to match(/\A#{host}\z/)
       end
     end
   end


### PR DESCRIPTION
- Moved the responsibility of returning the formatted message to the
  base `LogStashLogger::Formatter::Base` class, since it is there where
  the event is assembled and possibly cancelled by the user.
- Added a new private `#format_event` method that receives an event and
  returns the object to be logged to the device. This method may be
  overriden by the derived formatter classes.
- Public interface should be backwards compatible for non-cancelled
  events.
- TODO: Do all supported devices gracefully handle a `nil` response
  from the formatters?

Resolves #133