### PR TITLE
Require specific AWS gems for every class

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,10 @@ config.logstash.backoff = 1
 
 Add the aws-sdk gem to your Gemfile:
 
+    # aws-sdk < 3.0
+    gem 'aws-sdk-kinesis'
+
+    # aws-sdk >= 3.0
     gem 'aws-sdk'
 
 ```ruby
@@ -592,6 +596,10 @@ config.logstash.aws_secret_access_key = 'ASKASKHLD1234123412341234'
 
 Add the aws-sdk gem to your Gemfile:
 
+    # aws-sdk < 3.0
+    gem 'aws-sdk-firehose'
+
+    # aws-sdk >= 3.0
     gem 'aws-sdk'
 
 ```ruby

--- a/lib/logstash-logger/device/aws_stream.rb
+++ b/lib/logstash-logger/device/aws_stream.rb
@@ -1,4 +1,8 @@
-require 'aws-sdk'
+begin
+  require 'aws-sdk-core'
+rescue LoadError
+  require 'aws-sdk'
+end
 
 module LogStashLogger
   module Device

--- a/lib/logstash-logger/device/firehose.rb
+++ b/lib/logstash-logger/device/firehose.rb
@@ -1,4 +1,9 @@
-require 'aws-sdk'
+begin
+  require 'aws-sdk-firehose'
+rescue LoadError
+  require 'aws-sdk'
+end
+
 require 'logstash-logger/device/aws_stream'
 
 module LogStashLogger

--- a/lib/logstash-logger/device/kinesis.rb
+++ b/lib/logstash-logger/device/kinesis.rb
@@ -1,4 +1,9 @@
-require 'aws-sdk'
+begin
+  require 'aws-sdk-kinesis'
+rescue LoadError
+  require 'aws-sdk'
+end
+
 require 'logstash-logger/device/aws_stream'
 
 module LogStashLogger

--- a/spec/device/firehose_spec.rb
+++ b/spec/device/firehose_spec.rb
@@ -1,6 +1,6 @@
 require 'logstash-logger'
 
-describe LogStashLogger::Device::Kinesis do
+describe LogStashLogger::Device::Firehose do
   include_context 'device'
 
   let(:client) { double("Aws::Firehose::Client") }


### PR DESCRIPTION
`aws-sdk` gem has been split into several gems: https://github.com/aws/aws-sdk-ruby/blob/master/V3_UPGRADING_GUIDE.md
The changed code tries to require a new gem first but keeps backward compatibility with the previous `aws-sdk` gem version.