### PR TITLE
Reset logger state

### DIFF
--- a/lib/logstash-logger/buffer.rb
+++ b/lib/logstash-logger/buffer.rb
@@ -107,6 +107,8 @@ module LogStashLogger
     end
 
     def reset_buffer
+      reset_flush_timer_thread
+
       @buffer_state = {
         # items accepted from including class
         :pending_items => {},
@@ -126,7 +128,6 @@ module LogStashLogger
         :last_flush =>     Time.now,
         :timer =>          flush_timer_thread
       }
-
 
       # events we've accumulated
       buffer_clear_pending
@@ -303,6 +304,13 @@ module LogStashLogger
             end
           end
         end
+    end
+
+    def reset_flush_timer_thread
+      unless @flush_timer_thread.nil?
+        @flush_timer_thread.kill
+      @flush_timer_thread = nil
+      end
     end
 
     def buffer_clear_pending

--- a/lib/logstash-logger/buffer.rb
+++ b/lib/logstash-logger/buffer.rb
@@ -309,7 +309,7 @@ module LogStashLogger
     def reset_flush_timer_thread
       unless @flush_timer_thread.nil?
         @flush_timer_thread.kill
-      @flush_timer_thread = nil
+        @flush_timer_thread = nil
       end
     end
 

--- a/lib/logstash-logger/device/base.rb
+++ b/lib/logstash-logger/device/base.rb
@@ -39,6 +39,10 @@ module LogStashLogger
         @io && @io.flush
       end
 
+      def reset
+        close
+      end
+
       def close(opts = {})
         close!
       rescue => e

--- a/lib/logstash-logger/device/connectable.rb
+++ b/lib/logstash-logger/device/connectable.rb
@@ -107,6 +107,11 @@ module LogStashLogger
         fail NotImplementedError
       end
 
+      def reset
+        reset_buffer
+        close(flush: false)
+      end
+
       def reconnect
         close(flush: false)
         connect

--- a/lib/logstash-logger/logger.rb
+++ b/lib/logstash-logger/logger.rb
@@ -19,6 +19,10 @@ module LogStashLogger
       def flush
         !!(@device.flush if @device.respond_to?(:flush))
       end
+
+      def reset
+        @device.reset if @device.respond_to?(:reset)
+      end
     end
   end
 


### PR DESCRIPTION
Expose ` #reset` method which will clean up all allocated resources on a LogStashLogger. This is useful when, for example, forking a worker process in a web application, and you don't want to share the parent processes' resources with the children.

See #126 