### PR TITLE
Default AWS Credential Provider Chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,13 +601,13 @@ config.logstash.type = :firehose
 # Optional, will default to the 'logstash' delivery stream
 config.logstash.stream = 'my-stream-name'
 
-# Optional, will default to 'us-east-1'
+# Optional, will default to AWS default region config chain
 config.logstash.aws_region = 'us-west-2'
 
-# Optional, will default to the AWS_ACCESS_KEY_ID environment variable
+# Optional, will default to AWS default credential provider chain
 config.logstash.aws_access_key_id = 'ASKASKHLD12341'
 
-# Optional, will default to the AWS_SECRET_ACCESS_KEY environment variable
+# Optional, will default to AWS default credential provider chain
 config.logstash.aws_secret_access_key = 'ASKASKHLD1234123412341234'
 
 ```

--- a/lib/logstash-logger/device/aws_stream.rb
+++ b/lib/logstash-logger/device/aws_stream.rb
@@ -4,7 +4,6 @@ module LogStashLogger
   module Device
     class AwsStream < Connectable
 
-      DEFAULT_REGION = 'us-east-1'
       DEFAULT_STREAM = 'logstash'
 
       @stream_class = nil
@@ -18,9 +17,9 @@ module LogStashLogger
 
       def initialize(opts)
         super
-        @access_key_id = opts[:aws_access_key_id] || ENV['AWS_ACCESS_KEY_ID']
-        @secret_access_key = opts[:aws_secret_access_key] || ENV['AWS_SECRET_ACCESS_KEY']
-        @aws_region = opts[:aws_region] || DEFAULT_REGION
+        @access_key_id = opts[:aws_access_key_id]
+        @secret_access_key = opts[:aws_secret_access_key]
+        @aws_region = opts[:aws_region]
         @stream = opts[:stream] || DEFAULT_STREAM
       end
 
@@ -41,10 +40,10 @@ module LogStashLogger
       end
 
       def connect
-        @io = self.class.stream_class.new(
-          region: @aws_region,
-          credentials: ::Aws::Credentials.new(@access_key_id, @secret_access_key)
-        )
+        client_opts = {}
+        client_opts[:credentials] = Aws::Credentials.new(@access_key_id, @secret_access_key) unless @access_key_id == nil || @secret_access_key == nil
+        client_opts[:region] = @aws_region unless @aws_region == nil
+        @io = self.class.stream_class.new(client_opts)
       end
 
       def with_connection

--- a/spec/device/firehose_spec.rb
+++ b/spec/device/firehose_spec.rb
@@ -35,10 +35,6 @@ describe LogStashLogger::Device::Kinesis do
     firehose_device.write_one "foo"
   end
 
-  it "defaults the AWS region to us-east-1" do
-    expect(firehose_device.aws_region).to eq('us-east-1')
-  end
-
   it "defaults the Firehose stream to logstash" do
     expect(firehose_device.stream).to eq('logstash')
   end

--- a/spec/device/kinesis_spec.rb
+++ b/spec/device/kinesis_spec.rb
@@ -35,10 +35,6 @@ describe LogStashLogger::Device::Kinesis do
     kinesis_device.write_one "foo"
   end
 
-  it "defaults the AWS region to us-east-1" do
-    expect(kinesis_device.aws_region).to eq('us-east-1')
-  end
-
   it "defaults the kinesis stream to logstash" do
     expect(kinesis_device.stream).to eq('logstash')
   end


### PR DESCRIPTION
https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html#aws-ruby-sdk-setting-credentials

This will make it use the default credential provider chain which will for example enable to use instance profile.