### PR TITLE
Allow to configure buffer_max_items for Connectable devices using URI

### DIFF
--- a/lib/logstash-logger/device.rb
+++ b/lib/logstash-logger/device.rb
@@ -41,7 +41,11 @@ module LogStashLogger
       if uri = opts[:uri]
         require 'uri'
         parsed = ::URI.parse(uri)
-        {type: parsed.scheme, host: parsed.host, port: parsed.port, path: parsed.path}
+        type = parsed.scheme
+
+        device_klass_for(type).
+          opts_from_uri(parsed).
+          merge({type: type})
       end
     end
 

--- a/lib/logstash-logger/device/base.rb
+++ b/lib/logstash-logger/device/base.rb
@@ -5,6 +5,10 @@ module LogStashLogger
       attr_accessor :sync
       attr_accessor :error_logger
 
+      def self.opts_from_uri(uri)
+        {host: uri.host, port: uri.port, path: uri.path}
+      end
+
       def initialize(opts={})
         @sync = opts[:sync]
         @error_logger = opts.fetch(:error_logger, LogStashLogger.configuration.default_error_logger)

--- a/lib/logstash-logger/device/connectable.rb
+++ b/lib/logstash-logger/device/connectable.rb
@@ -7,6 +7,13 @@ module LogStashLogger
 
       attr_accessor :buffer_logger
 
+      def self.opts_from_uri(uri)
+        params = Hash[CGI.parse(uri.query).map {|k,v| [k,v.first]}]
+        super.merge({
+          buffer_max_items: params["buffer_max_items"] ? params["buffer_max_items"].to_i : nil,
+        })
+      end
+
       def initialize(opts = {})
         super
 


### PR DESCRIPTION
We are using URI in an environment variable in order to configure our `LogstashLogger`:

```ruby
# Read the URI from an environment variable
logger = LogStashLogger.new(uri: ENV['LOGSTASH_URI'])
```

The default value for `buffer_max_items` was not enough for our production needs and currently cannot be controlled using the `:uri` option.

This PR adds support specifically for `buffer_max_items` but opens the door to type-specific options to be parsed / validated by individual device implementations.