### PR TITLE
Allow passing integers as tags to TaggedLogging::Formatter

### DIFF
--- a/lib/logstash-logger/tagged_logging.rb
+++ b/lib/logstash-logger/tagged_logging.rb
@@ -19,7 +19,9 @@ module LogStashLogger
       end
 
       def push_tags(*tags)
-        tags.flatten.reject{ |t| t.nil? || t.empty? }.tap do |new_tags|
+        non_empty_tags = tags.flatten.compact.reject { |t| t.respond_to?(:empty?) && t.empty? }
+
+        non_empty_tags.tap do |new_tags|
           current_tags.concat new_tags
         end
       end

--- a/spec/tagged_logging_spec.rb
+++ b/spec/tagged_logging_spec.rb
@@ -28,5 +28,20 @@ describe LogStashLogger do
 
       logger.info(message)
     end
+
+    context 'when tag is an integer' do
+      let(:tag) { 10 }
+
+      it "puts the integer into the tags array on the logstash event" do
+        expect(logdev).to receive(:write) do |event_string|
+          event = JSON.parse(event_string)
+          expect(event['tags']).to match_array([10])
+        end
+
+        logger.tagged(tag) do
+          logger.info(message)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Logstash and Elasticsearch accept integer values for keyword type fields, such as `tags`. 

LogStashLogger filters tags, not to pass `nil`s or empty strings as tags to Logstash. 
However, the empty string check does fail on everything that is not a string, and it does so in not a
very friendly manner:
```ruby
irb(main):005:0> stdout_logger.tagged('test', 10) {}
Traceback (most recent call last):
        5: from /Users/irvingwashington/.rubies/ruby-2.5.3/bin/irb:11:in `<main>'
        4: from (irb):5
        3: from /Users/irvingwashington/.gem/ruby/2.5.3/gems/logstash-logger-0.25.1/lib/logstash-logger/tagged_logging.rb:5:in `tagged'
        2: from /Users/irvingwashington/.gem/ruby/2.5.3/gems/logstash-logger-0.25.1/lib/logstash-logger/tagged_logging.rb:18:in `tagged'
        1: from /Users/irvingwashington/.gem/ruby/2.5.3/gems/logstash-logger-0.25.1/lib/logstash-logger/tagged_logging.rb:18:in `ensure in tagged'
NoMethodError (undefined method `size' for nil:NilClass)
```

This PR makes that check happen only on objects that respond to `#empty?`.

