### PR TITLE
Allow .reset on MultiLogger

### DIFF
--- a/lib/logstash-logger/multi_logger.rb
+++ b/lib/logstash-logger/multi_logger.rb
@@ -70,7 +70,7 @@ module LogStashLogger
     def method_missing(name, *args, &block)
       @loggers.each do |logger|
         if logger.respond_to?(name)
-          logger.send(name, args, &block)
+          logger.send(name, *args, &block)
         end
       end
     end

--- a/spec/multi_logger_spec.rb
+++ b/spec/multi_logger_spec.rb
@@ -56,4 +56,12 @@ describe LogStashLogger::MultiLogger do
       logger.info 'test'
     end
   end
+
+  it "can call .reset on each logger" do
+    subject.loggers.each do |logger|
+      expect(logger).to receive(:reset).and_call_original
+    end
+
+    subject.reset
+  end
 end


### PR DESCRIPTION
I'm using a MultiLogger and tried setting up the Phusion Passenger cleanup as specified:

```ruby
::PhusionPassenger.on_event(:starting_worker_process) do |forked|
  Rails.logger.reset
end
```

but ran into the following error:

```
wrong number of arguments (given 1, expected 0) (ArgumentError)
  /usr/local/rvm/gems/ruby-2.5.3/gems/logstash-logger-0.26.1/lib/logstash-logger/logger.rb:23:in `reset'
  /usr/local/rvm/gems/ruby-2.5.3/gems/logstash-logger-0.26.1/lib/logstash-logger/multi_logger.rb:73:in `block in method_missing'
  /usr/local/rvm/gems/ruby-2.5.3/gems/logstash-logger-0.26.1/lib/logstash-logger/multi_logger.rb:71:in `each'
  /usr/local/rvm/gems/ruby-2.5.3/gems/logstash-logger-0.26.1/lib/logstash-logger/multi_logger.rb:71:in `method_missing'
```

I dug a bit and think this PR should fix it. Thanks!