### PR TITLE
Instantiate custom formatter classes with customize_event keyword arg

### DIFF
--- a/lib/logstash-logger/formatter.rb
+++ b/lib/logstash-logger/formatter.rb
@@ -20,7 +20,7 @@ module LogStashLogger
       formatter = if custom_formatter_instance?(formatter_type)
         formatter_type
       elsif custom_formatter_class?(formatter_type)
-        formatter_type.new
+        initialize_custom_formatter_klass(formatter_type, customize_event)
       else
         formatter_klass(formatter_type).new(customize_event: customize_event)
       end
@@ -46,6 +46,14 @@ module LogStashLogger
 
     def self.custom_formatter_class?(formatter_type)
       formatter_type.is_a?(Class) && formatter_type.method_defined?(:call)
+    end
+
+    def self.initialize_custom_formatter_klass(formatter_klass, customize_event)
+      if formatter_klass.instance_method(:initialize).parameters.include?([:key, :customize_event])
+        formatter_klass.new(customize_event: customize_event)
+      else
+        formatter_klass.new
+      end
     end
 	end
 end

--- a/spec/formatter_spec.rb
+++ b/spec/formatter_spec.rb
@@ -35,6 +35,23 @@ describe LogStashLogger::Formatter do
         end
       end
 
+      context "formatter class that accepts customize_event keyword arg in initializer" do
+        let(:formatter) do
+          Class.new do
+            def initialize(customize_event: nil)
+            end
+
+            def call
+            end
+          end
+        end
+
+        it "returns a new instance of the class" do
+          expect(formatter).to receive(:new).with(hash_including(:customize_event)).and_call_original
+          expect(subject).to be_a formatter
+        end
+      end
+
       context "formatter instance" do
         let(:formatter) { ::Logger::Formatter.new }
 


### PR DESCRIPTION
In my application, I want to be able to build a formatter that inherits from `LogStashLogger::Formatter::Base` to get its overall behavior, and also specifically want to take advantage of the `customize_event` functionality in that class. So I want to create a class like the following, for example:

```ruby
class MyFormatter < LogStashLogger::Formatter::Base
  private

  def format_event(event)
    # mutate event here...
    "#{event.to_json}\n"
  end
end
```

As is, this is not possible because `LogStashLogger::Formatter.build_formatter` does not pass in `customize_event` to the initializer of custom formatter classes even when they accept that keyword arg.