### PR TITLE
Gracefully handle json Encoding::UndefinedConversionError 

### DIFF
--- a/lib/logstash-logger/formatter.rb
+++ b/lib/logstash-logger/formatter.rb
@@ -10,11 +10,11 @@ module LogStashLogger
     autoload :Cee, 'logstash-logger/formatter/cee'
     autoload :CeeSyslog, 'logstash-logger/formatter/cee_syslog'
 
-    def self.new(formatter_type, customize_event: nil)
-      build_formatter(formatter_type, customize_event)
+    def self.new(formatter_type, customize_event: nil, error_logger: LogStashLogger.configuration.default_error_logger)
+      build_formatter(formatter_type, customize_event, error_logger)
     end
 
-    def self.build_formatter(formatter_type, customize_event)
+    def self.build_formatter(formatter_type, customize_event, error_logger)
       formatter_type ||= DEFAULT_FORMATTER
 
       formatter = if custom_formatter_instance?(formatter_type)
@@ -22,7 +22,7 @@ module LogStashLogger
       elsif custom_formatter_class?(formatter_type)
         formatter_type.new
       else
-        formatter_klass(formatter_type).new(customize_event: customize_event)
+        formatter_klass(formatter_type).new(customize_event: customize_event, error_logger: error_logger)
       end
 
       formatter.send(:extend, ::LogStashLogger::TaggedLogging::Formatter)

--- a/lib/logstash-logger/formatter/base.rb
+++ b/lib/logstash-logger/formatter/base.rb
@@ -73,7 +73,7 @@ module LogStashLogger
 
       def force_utf8_encoding(event)
         original_message = event.instance_variable_get(:@data)['message']
-        event.message = original_message.force_encoding('UTF-8')
+        event.message = original_message.force_encoding(Encoding::UTF_8).scrub
         event
       end
 

--- a/lib/logstash-logger/formatter/base.rb
+++ b/lib/logstash-logger/formatter/base.rb
@@ -7,10 +7,12 @@ module LogStashLogger
     HOST = ::Socket.gethostname
 
     class Base < ::Logger::Formatter
+      attr_accessor :error_logger
       include ::LogStashLogger::TaggedLogging::Formatter
 
-      def initialize(customize_event: nil)
+      def initialize(customize_event: nil, error_logger: LogStashLogger.configuration.default_error_logger)
         @customize_event = customize_event
+        @error_logger = error_logger
         super()
       end
 
@@ -73,6 +75,10 @@ module LogStashLogger
         original_message = event.instance_variable_get(:@data)['message']
         event.message = original_message.force_encoding('UTF-8')
         event
+      end
+
+      def log_error(e)
+        error_logger.error "[#{self.class}] #{e.class} - #{e.message}"
       end
     end
   end

--- a/lib/logstash-logger/formatter/base.rb
+++ b/lib/logstash-logger/formatter/base.rb
@@ -70,11 +70,9 @@ module LogStashLogger
       end
 
       def force_utf8_encoding(event)
-        new_event = event.dup
-        new_data = {}
-        new_event.instance_variable_get(:@data).each { |k, v| new_data[k] = v.to_s.force_encoding('UTF-8') }
-        new_event.instance_variable_set(:@data, new_data)
-        new_event
+        original_message = event.instance_variable_get(:@data)['message']
+        event.message = original_message.force_encoding('UTF-8')
+        event
       end
     end
   end

--- a/lib/logstash-logger/formatter/base.rb
+++ b/lib/logstash-logger/formatter/base.rb
@@ -68,6 +68,14 @@ module LogStashLogger
       def format_event(event)
         event
       end
+
+      def force_utf8_encoding(event)
+        new_event = event.dup
+        new_data = {}
+        new_event.instance_variable_get(:@data).each { |k, v| new_data[k] = v.to_s.force_encoding('UTF-8') }
+        new_event.instance_variable_set(:@data, new_data)
+        new_event
+      end
     end
   end
 end

--- a/lib/logstash-logger/formatter/json.rb
+++ b/lib/logstash-logger/formatter/json.rb
@@ -5,6 +5,9 @@ module LogStashLogger
 
       def format_event(event)
         event.to_json
+      rescue Encoding::UndefinedConversionError => e
+        log_error(e)
+        force_utf8_encoding(event).to_json
       end
     end
   end

--- a/lib/logstash-logger/formatter/json_lines.rb
+++ b/lib/logstash-logger/formatter/json_lines.rb
@@ -5,6 +5,9 @@ module LogStashLogger
 
       def format_event(event)
         "#{event.to_json}\n"
+      rescue Encoding::UndefinedConversionError => e
+        log_error(e)
+        "#{force_utf8_encoding(event).to_json}\n"
       end
     end
   end

--- a/lib/logstash-logger/logger.rb
+++ b/lib/logstash-logger/logger.rb
@@ -50,7 +50,7 @@ module LogStashLogger
   end
 
   def self.build_logger(opts)
-    formatter = Formatter.new(opts.delete(:formatter), customize_event: opts.delete(:customize_event))
+    formatter = Formatter.new(opts.delete(:formatter), customize_event: opts.delete(:customize_event), error_logger: opts.fetch(:error_logger))
 
     logger_type = opts[:type].to_s.to_sym
     logger = case logger_type

--- a/spec/formatter/base_spec.rb
+++ b/spec/formatter/base_spec.rb
@@ -25,6 +25,21 @@ describe LogStashLogger::Formatter::Base do
     end
   end
 
+  describe '#force_utf8_encoding' do
+    let(:event) { LogStash::Event.new("message" => "foo".force_encoding('ASCII-8BIT')) }
+
+    it 'returns a new event' do
+      expect(subject.send(:force_utf8_encoding, event)).not_to eq(event)
+    end
+
+    it 'forces all event data to UTF-8 encoding' do
+      updated_event_data = subject.send(:force_utf8_encoding, event).instance_variable_get(:@data)
+      updated_event_data.each_value do |value|
+        expect(value.encoding.name).to eq('UTF-8')
+      end
+    end
+  end
+
   describe "#build_event" do
     let(:event) { formatted_message }
 

--- a/spec/formatter/base_spec.rb
+++ b/spec/formatter/base_spec.rb
@@ -28,15 +28,14 @@ describe LogStashLogger::Formatter::Base do
   describe '#force_utf8_encoding' do
     let(:event) { LogStash::Event.new("message" => "foo".force_encoding('ASCII-8BIT')) }
 
-    it 'returns a new event' do
-      expect(subject.send(:force_utf8_encoding, event)).not_to eq(event)
+    it 'returns the same event' do
+      expect(subject.send(:force_utf8_encoding, event)).to eq(event)
     end
 
-    it 'forces all event data to UTF-8 encoding' do
-      updated_event_data = subject.send(:force_utf8_encoding, event).instance_variable_get(:@data)
-      updated_event_data.each_value do |value|
-        expect(value.encoding.name).to eq('UTF-8')
-      end
+    it 'forces the event message to UTF-8 encoding' do
+      subject.send(:force_utf8_encoding, event)
+      updated_event_data = event.instance_variable_get(:@data)
+      expect(updated_event_data['message'].encoding.name).to eq('UTF-8')
     end
   end
 

--- a/spec/formatter/json_lines_spec.rb
+++ b/spec/formatter/json_lines_spec.rb
@@ -11,4 +11,27 @@ describe LogStashLogger::Formatter::JsonLines do
   it "terminates with a line break" do
     expect(formatted_message[-1]).to eq("\n")
   end
+
+  context 'encoding error is raised' do
+    let(:message) { "foo x\xc3x".force_encoding('ASCII-8BIT') }
+
+    before do
+      allow(subject).to receive(:error_logger).and_return(Logger.new('/dev/null'))
+    end
+
+    it 'logs the error' do
+      expect(subject).to receive(:log_error)
+      formatted_message
+    end
+
+    it 'forces the message encoding to utf8' do
+      expect(subject).to receive(:force_utf8_encoding)
+      formatted_message
+    end
+
+    it "outputs in JSON format with message encoding updated to utf8" do
+      json_message = JSON.parse(formatted_message)
+      expect(json_message["message"]).to eq(message.force_encoding(Encoding::UTF_8).scrub)
+    end
+  end
 end

--- a/spec/formatter/json_spec.rb
+++ b/spec/formatter/json_spec.rb
@@ -7,4 +7,27 @@ describe LogStashLogger::Formatter::Json do
     json_message = JSON.parse(formatted_message)
     expect(json_message["message"]).to eq(message)
   end
+
+  context 'encoding error is raised' do
+    let(:message) { "foo x\xc3x".force_encoding('ASCII-8BIT') }
+
+    before do
+      allow(subject).to receive(:error_logger).and_return(Logger.new('/dev/null'))
+    end
+
+    it 'logs the error' do
+      expect(subject).to receive(:log_error)
+      formatted_message
+    end
+
+    it 'forces the message encoding to utf8' do
+      expect(subject).to receive(:force_utf8_encoding)
+      formatted_message
+    end
+
+    it "outputs in JSON format with message encoding updated to utf8" do
+      json_message = JSON.parse(formatted_message)
+      expect(json_message["message"]).to eq(message.force_encoding(Encoding::UTF_8).scrub)
+    end
+  end
 end


### PR DESCRIPTION
This addresses: #159 and #158 

## Things Done:
- Pass error logger through to formatter class
- Add exception handler for encoding errors
- Force utf 8 encoding and try again to format the event
- Unit tests