### PR TITLE
Feat: Add support for host sni when using tcp/ssl

### DIFF
--- a/lib/logstash-logger/device/tcp.rb
+++ b/lib/logstash-logger/device/tcp.rb
@@ -30,6 +30,7 @@ module LogStashLogger
 
       def connect
         if use_ssl?
+          io.hostname = hostname
           io.connect
           verify_hostname!
         end

--- a/spec/device/tcp_spec.rb
+++ b/spec/device/tcp_spec.rb
@@ -12,6 +12,7 @@ describe LogStashLogger::Device::TCP do
 
     allow(OpenSSL::SSL::SSLSocket).to receive(:new) { ssl_socket }
     allow(ssl_socket).to receive(:connect)
+    allow(ssl_socket).to receive(:hostname=)
     allow(ssl_socket).to receive(:post_connection_check)
     allow(ssl_tcp_device).to receive(:warn)
   end


### PR DESCRIPTION
In order to support using host sni for an ssl tcp connection, this commit modifies the tcp class to set the hostname field on the ssl connection. This allows the receiving end to use this hostname as part of the TLS connection to indicate which certificate/service to use.