### PR TITLE
Fixed argument error for unknown keyword :sync with Redis connection.

### DIFF
--- a/lib/logstash-logger/device/redis.rb
+++ b/lib/logstash-logger/device/redis.rb
@@ -13,6 +13,7 @@ module LogStashLogger
         @buffer_group = @list
 
         normalize_path(opts)
+        delete_unknown_keywords(opts)
 
         @redis_options = opts
       end
@@ -64,6 +65,12 @@ module LogStashLogger
         end
       end
 
+      def delete_unknown_keywords(opts)
+        # due to restrictions in redis client version >= 5
+        # Continous error is being logged for unknown keywords, at present there is only one i.e. :sync
+        # to prevent that adding following line :)
+        opts.delete(:sync)
+      end
     end
   end
 end


### PR DESCRIPTION
After using redis > 5.0, it will raise error
```
[LogStashLogger::Device::Redis] ArgumentError - unknown keyword: :sync
```
Redis client accepts a keyword argument, but `sync` is not a valid argument option anymore.