### PR TITLE
Wrap hostname into a hash to ensure compatibility with Elastic >= 8

### DIFF
--- a/lib/logstash-logger/formatter/base.rb
+++ b/lib/logstash-logger/formatter/base.rb
@@ -6,6 +6,7 @@ module LogStashLogger
   module Formatter
     HOST = {
       'hostname' => ::Socket.gethostname,
+      'ip' => Socket.ip_address_list.reject(&:ipv4_loopback?).reject(&:ipv6_loopback?).map(&:ip_address)
   }.freeze
 
     class Base < ::Logger::Formatter

--- a/lib/logstash-logger/formatter/base.rb
+++ b/lib/logstash-logger/formatter/base.rb
@@ -4,7 +4,9 @@ require 'time'
 
 module LogStashLogger
   module Formatter
-    HOST = ::Socket.gethostname
+    HOST = {
+      'hostname' => ::Socket.gethostname,
+  }.freeze
 
     class Base < ::Logger::Formatter
       include ::LogStashLogger::TaggedLogging::Formatter

--- a/lib/logstash-logger/formatter/cee_syslog.rb
+++ b/lib/logstash-logger/formatter/cee_syslog.rb
@@ -9,7 +9,7 @@ module LogStashLogger
       private
 
       def build_facility(host)
-        facility = host.dup
+        facility = host['hostname'.freeze].dup
         facility << " #{@progname}" if @progname
         facility
       end

--- a/spec/formatter/base_spec.rb
+++ b/spec/formatter/base_spec.rb
@@ -81,7 +81,7 @@ describe LogStashLogger::Formatter::Base do
       end
 
       it "adds host" do
-        expect(event['host']).to eq(hostname)
+        expect(event['host']['hostname']).to eq(hostname)
       end
     end
 

--- a/spec/formatter/cee_syslog_spec.rb
+++ b/spec/formatter/cee_syslog_spec.rb
@@ -22,21 +22,21 @@ describe LogStashLogger::Formatter::CeeSyslog do
   end
 
   describe "#build_facility" do
-    let(:host) { Socket.gethostname }
+    let(:host) { { 'hostname' => Socket.gethostname } }
 
     before do
       formatted_message
     end
 
     it "includes hostname and progname" do
-      expect(subject.send(:build_facility, host)).to match(/\A#{host}\s#{progname}\z/)
+      expect(subject.send(:build_facility, host)).to match(/\A#{host['hostname']}\s#{progname}\z/)
     end
 
     context "without progname" do
       let(:progname) { nil }
 
       it "only includes hostname" do
-        expect(subject.send(:build_facility, host)).to match(/\A#{host}\z/)
+        expect(subject.send(:build_facility, host)).to match(/\A#{host['hostname']}\z/)
       end
     end
   end

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -58,14 +58,14 @@ describe LogStashLogger do
 
     expect(listener_event['severity']).to eql('INFO')
     expect(listener_event['message']).to eq(message)
-    expect(listener_event['host']).to eq(hostname)
+    expect(listener_event['host']['hostname']).to eq(hostname)
   end
 
   it 'takes a logstash-formatted json string as input and writes out a logstash event' do
     logger.info(logstash_event.to_json)
 
     expect(listener_event['message']).to eq(logstash_event['message'])
-    expect(listener_event['host']).to eq(hostname)
+    expect(listener_event['host']['hostname']).to eq(hostname)
   end
 
   it 'takes a LogStash::Event as input and writes it out intact' do
@@ -74,7 +74,7 @@ describe LogStashLogger do
     expect(listener_event['message']).to eq(logstash_event['message'])
     expect(listener_event['severity']).to eq(logstash_event['severity'])
     expect(listener_event['@timestamp'].iso8601).to eq(logstash_event.timestamp.iso8601)
-    expect(listener_event['host']).to eq(hostname)
+    expect(listener_event['host']['hostname']).to eq(hostname)
   end
 
   it 'takes a data hash as input and writes out a logstash event' do
@@ -89,7 +89,7 @@ describe LogStashLogger do
     expect(listener_event['message']).to eq(data["message"])
     expect(listener_event['severity']).to eq(data['severity'])
     expect(listener_event['foo']).to eq(data['foo'])
-    expect(listener_event['host']).to eq(hostname)
+    expect(listener_event['host']['hostname']).to eq(hostname)
     expect(listener_event['@timestamp']).to_not be_nil
   end
 
@@ -99,7 +99,7 @@ describe LogStashLogger do
     logger.info(message)
 
     expect(listener_event['message']).to eq(message.inspect)
-    expect(listener_event['host']).to eq(hostname)
+    expect(listener_event['host']['hostname']).to eq(hostname)
     expect(listener_event['severity']).to eq('INFO')
   end
 


### PR DESCRIPTION
Starting with version 8 of the ELK stack, all Logstash plugins run in [ECS compatibility mode](https://www.elastic.co/docs/reference/logstash/ecs-ls). That means that common fields and plugins are expected to honor the schema [described here](https://github.com/elastic/ecs/blob/main/generated/csv/fields.csv).

According to ECS, the "host" field is [now expected to be a map of properties](https://www.elastic.co/docs/reference/ecs/ecs-host) instead of a string. 

Using the current version of the gem, pushing data to Logstash `json_lines` codec moreover produces an exception (`Could not set field 'ip' on object 'host.domain.tld' to value`) as Logstash is expecting a json map, resulting in the **whole** JSON payload to be treated as a string and put to the "message" property sent to Elasticsearch.

As this is the new default behavior of Logtash, this PR wraps the hostname (formerly `{ "host": "host.domain.tld" }`) into a JSON map (`{ "host": { "hostname": "host.domain.tld"  }`).