### PR TITLE
Handle non-string tags in tagged logging

### DIFF
--- a/lib/logstash-logger/tagged_logging.rb
+++ b/lib/logstash-logger/tagged_logging.rb
@@ -19,7 +19,7 @@ module LogStashLogger
       end
 
       def push_tags(*tags)
-        tags.flatten.reject{ |t| t.nil? || t.empty? }.tap do |new_tags|
+        tags.flatten.reject { |tag| tag.nil? || (tag.respond_to?(:empty?) && tag.empty?) }.tap do |new_tags|
           current_tags.concat new_tags
         end
       end

--- a/spec/tagged_logging_spec.rb
+++ b/spec/tagged_logging_spec.rb
@@ -28,5 +28,18 @@ describe LogStashLogger do
 
       logger.info(message)
     end
+
+    it "allows non-string tags" do
+      numeric_tag = 123
+      expect(logdev).to receive(:write) do |event_string|
+        event = JSON.parse(event_string)
+        expect(event['tags']).to match_array([numeric_tag])
+        expect(event['message']).to eq(message)
+      end
+
+      logger.tagged(numeric_tag) do
+        logger.info(message)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Motivation

- Allow tagged logging to accept non-string tags (e.g. integers) without raising errors when `empty?` is not defined on the tag object.

### Description

- Change `push_tags` to only call `empty?` if the tag `respond_to?(:empty?)` and otherwise only reject `nil` values in `lib/logstash-logger/tagged_logging.rb`.
- Add a spec that verifies numeric (non-string) tags are propagated into the event `tags` array in `spec/tagged_logging_spec.rb`.
- Files modified: `lib/logstash-logger/tagged_logging.rb` and `spec/tagged_logging_spec.rb`.

### Testing

- Added `spec/tagged_logging_spec.rb` coverage for non-string tags but the test run could not be executed because `bundle exec rspec spec/tagged_logging_spec.rb` failed in this environment due to missing Bundler/RSpec executables.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69728d4b3ce0832bb0d3fa7fff1ab40c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Tagged logging robustness**
> 
> - Update `push_tags` to only call `empty?` when a tag responds to it, rejecting only `nil` and empty values; prevents errors for non-string tags.
> - Add spec verifying numeric tags are included in `tags` and that no-tags logs omit the `tags` field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46fd21543d2b087becd0d04661df4d2c51b518a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->