### PR TITLE
Put timestamp first in JSON output. Fixes #168

### DIFF
--- a/lib/logstash-logger/formatter/base.rb
+++ b/lib/logstash-logger/formatter/base.rb
@@ -40,15 +40,24 @@ module LogStashLogger
                   when LogStash::Event
                     data.clone
                   when Hash
-                    event_data = data.clone
-                    event_data['message'.freeze] = event_data.delete(:message) if event_data.key?(:message)
-                    event_data['tags'.freeze] = event_data.delete(:tags) if event_data.key?(:tags)
-                    event_data['source'.freeze] = event_data.delete(:source) if event_data.key?(:source)
-                    event_data['type'.freeze] = event_data.delete(:type) if event_data.key?(:type)
-                    event_data['@timestamp'.freeze] = time
+                    event_data = { '@timestamp'.freeze => time }
+                    data.each do |key, value|
+                      case key
+                      when :message, 'message'
+                        event_data['message'.freeze] = value
+                      when :tags, 'tags'
+                        event_data['tags'.freeze] = value
+                      when :source, 'source'
+                        event_data['source'.freeze] = value
+                      when :type, 'type'
+                        event_data['type'.freeze] = value
+                      else
+                        event_data[key] = value
+                      end
+                    end
                     LogStash::Event.new(event_data)
                   else
-                    LogStash::Event.new("message".freeze => msg2str(data), "@timestamp".freeze => time)
+                    LogStash::Event.new("@timestamp".freeze => time, "message".freeze => msg2str(data))
                 end
 
         event['severity'.freeze] ||= severity

--- a/spec/formatter/json_spec.rb
+++ b/spec/formatter/json_spec.rb
@@ -30,4 +30,30 @@ describe LogStashLogger::Formatter::Json do
       expect(json_message["message"]).to eq(message.force_encoding(Encoding::UTF_8).scrub)
     end
   end
+
+  context "timestamp ordering" do
+    let(:message) { { message: 'test', foo: 'bar' } }
+
+    it "places @timestamp first in JSON output" do
+      timestamp_index = formatted_message.index('"@timestamp"')
+      message_index = formatted_message.index('"message"')
+
+      expect(timestamp_index).not_to be_nil
+      expect(message_index).not_to be_nil
+      expect(timestamp_index).to be < message_index
+    end
+  end
+
+  context "key ordering" do
+    let(:message) { { foo: 'bar', baz: 'qux' } }
+
+    it "preserves custom field order in JSON output" do
+      foo_index = formatted_message.index('"foo"')
+      baz_index = formatted_message.index('"baz"')
+
+      expect(foo_index).not_to be_nil
+      expect(baz_index).not_to be_nil
+      expect(foo_index).to be < baz_index
+    end
+  end
 end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves JSON event construction and ordering for predictable log output.
> 
> - Reworks `build_event` to construct `event_data` starting with `"@timestamp"`, then iterates input keys to map `message/tags/source/type` while preserving original key order; adjusts non-hash case to emit `"@timestamp"` before `"message"` in `lib/logstash-logger/formatter/base.rb`
> - Adds tests validating `"@timestamp"` precedes `"message"` and that custom fields preserve order in `spec/formatter/json_spec.rb`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f039cce84babe366c34a19c0681e6a854e67569. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->